### PR TITLE
Add Orbit Flip Frenzy iOS game implementation

### DIFF
--- a/OrbitFlipFrenzy/AdManager.swift
+++ b/OrbitFlipFrenzy/AdManager.swift
@@ -1,0 +1,36 @@
+import Foundation
+import UIKit
+
+public protocol AdManaging {
+    func showRewardedAd(from viewController: UIViewController, completion: @escaping () -> Void)
+    var isRewardedReady: Bool { get }
+}
+
+public final class AdManager: AdManaging {
+    private var lastShown: Date?
+
+    public init() {}
+
+    public var isRewardedReady: Bool {
+        true
+    }
+
+    public func showRewardedAd(from viewController: UIViewController, completion: @escaping () -> Void) {
+        lastShown = Date()
+        let alert = UIAlertController(title: "Rewarded Ad", message: "Watching...", preferredStyle: .alert)
+        viewController.present(alert, animated: true)
+        let spinner = UIActivityIndicatorView(style: .large)
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        alert.view.addSubview(spinner)
+        NSLayoutConstraint.activate([
+            spinner.centerXAnchor.constraint(equalTo: alert.view.centerXAnchor),
+            spinner.bottomAnchor.constraint(equalTo: alert.view.bottomAnchor, constant: -20)
+        ])
+        spinner.startAnimating()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+            alert.dismiss(animated: true) {
+                completion()
+            }
+        }
+    }
+}

--- a/OrbitFlipFrenzy/Analytics.swift
+++ b/OrbitFlipFrenzy/Analytics.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public enum AnalyticsEvent: CustomStringConvertible {
+    case gameStart(level: Int)
+    case gameOver(score: Int, duration: TimeInterval)
+    case nearMiss(count: Int)
+    case powerupUsed(type: PowerUp)
+    case adWatched(placement: String)
+    case shareInitiated
+
+    public var description: String {
+        switch self {
+        case let .gameStart(level):
+            return "gameStart(level: \(level))"
+        case let .gameOver(score, duration):
+            return String(format: "gameOver(score: %d, duration: %.2f)", score, duration)
+        case let .nearMiss(count):
+            return "nearMiss(count: \(count))"
+        case let .powerupUsed(type):
+            return "powerupUsed(\(type))"
+        case let .adWatched(placement):
+            return "adWatched(placement: \(placement))"
+        case .shareInitiated:
+            return "shareInitiated"
+        }
+    }
+}
+
+public protocol AnalyticsTracking {
+    func track(_ event: AnalyticsEvent)
+}
+
+public final class Analytics: AnalyticsTracking {
+    public init() {}
+
+    public func track(_ event: AnalyticsEvent) {
+        print("Analytics: \(event.description)")
+    }
+}

--- a/OrbitFlipFrenzy/AssetGenerator.swift
+++ b/OrbitFlipFrenzy/AssetGenerator.swift
@@ -1,0 +1,195 @@
+import Foundation
+import SpriteKit
+import UIKit
+
+public protocol AssetGenerating {
+    func makeBackground(size: CGSize) -> SKSpriteNode
+    func makePlayerNode() -> SKShapeNode
+    func makeRingNode(radius: CGFloat, lineWidth: CGFloat, color: UIColor, glow: CGFloat) -> SKShapeNode
+    func makeObstacleNode(size: CGSize) -> SKShapeNode
+    func makePowerUpNode(of type: PowerUpType) -> SKShapeNode
+    func makeButtonNode(text: String, size: CGSize) -> SKSpriteNode
+    func makeParticleTexture(radius: CGFloat, color: UIColor) -> SKTexture
+}
+
+public final class AssetGenerator: AssetGenerating {
+    private let buttonFont = UIFont(name: "Orbitron-Bold", size: 20) ?? UIFont.systemFont(ofSize: 20, weight: .bold)
+
+    public init() {}
+
+    public func makeBackground(size: CGSize) -> SKSpriteNode {
+        let texture = gradientTexture(size: size, colors: [GamePalette.deepNavy, GamePalette.royalBlue])
+        let node = SKSpriteNode(texture: texture)
+        node.zPosition = -10
+        return node
+    }
+
+    public func makePlayerNode() -> SKShapeNode {
+        let radius: CGFloat = 18
+        let node = SKShapeNode(circleOfRadius: radius)
+        node.fillColor = GamePalette.neonMagenta
+        node.strokeColor = GamePalette.cyan
+        node.lineWidth = 4
+        node.glowWidth = 8
+        node.physicsBody = SKPhysicsBody(circleOfRadius: radius)
+        node.physicsBody?.isDynamic = true
+        node.physicsBody?.allowsRotation = false
+        node.physicsBody?.categoryBitMask = PhysicsCategory.player
+        node.physicsBody?.contactTestBitMask = PhysicsCategory.obstacle | PhysicsCategory.powerUp
+        node.physicsBody?.collisionBitMask = 0
+        node.name = "player"
+
+        if let trailTexture = makeParticleTexture(radius: 4, color: GamePalette.neonMagenta) {
+            let emitter = SKEmitterNode()
+            emitter.particleTexture = trailTexture
+            emitter.particleBirthRate = GameConstants.particleBirthRate
+            emitter.particleLifetime = GameConstants.particleLifetime
+            emitter.particleAlpha = 0.8
+            emitter.particleSpeed = 50
+            emitter.particleColorBlendFactor = 1
+            emitter.targetNode = node
+            emitter.particleColor = GamePalette.neonMagenta
+            emitter.position = .zero
+            emitter.zPosition = -1
+            node.addChild(emitter)
+        }
+
+        return node
+    }
+
+    public func makeRingNode(radius: CGFloat, lineWidth: CGFloat, color: UIColor, glow: CGFloat) -> SKShapeNode {
+        let node = SKShapeNode(circleOfRadius: radius)
+        node.lineWidth = lineWidth
+        node.strokeColor = color
+        node.fillColor = .clear
+        node.glowWidth = glow
+        node.alpha = 0.9
+        return node
+    }
+
+    public func makeObstacleNode(size: CGSize) -> SKShapeNode {
+        let path = UIBezierPath()
+        let halfWidth = size.width / 2
+        let halfHeight = size.height / 2
+        path.move(to: CGPoint(x: -halfWidth, y: -halfHeight))
+        path.addLine(to: CGPoint(x: halfWidth, y: -halfHeight))
+        path.addLine(to: CGPoint(x: 0, y: halfHeight))
+        path.close()
+        let node = SKShapeNode(path: path.cgPath)
+        node.fillColor = GamePalette.solarGold
+        node.strokeColor = GamePalette.cyan
+        node.lineWidth = 2
+        node.glowWidth = 4
+        node.physicsBody = SKPhysicsBody(polygonFrom: path.cgPath)
+        node.physicsBody?.isDynamic = false
+        node.physicsBody?.categoryBitMask = PhysicsCategory.obstacle
+        node.physicsBody?.contactTestBitMask = PhysicsCategory.player
+        node.physicsBody?.collisionBitMask = 0
+        node.name = "obstacle"
+        return node
+    }
+
+    public func makePowerUpNode(of type: PowerUpType) -> SKShapeNode {
+        let node: SKShapeNode
+        switch type {
+        case .shield:
+            node = SKShapeNode(circleOfRadius: 20)
+            node.strokeColor = GamePalette.cyan
+            node.fillColor = GamePalette.cyan.withAlphaComponent(0.3)
+        case .slowMo:
+            let rect = CGRect(x: -18, y: -18, width: 36, height: 36)
+            node = SKShapeNode(rectOf: rect.size, cornerRadius: 10)
+            node.fillColor = GamePalette.solarGold.withAlphaComponent(0.3)
+            node.strokeColor = GamePalette.solarGold
+        case .magnet:
+            let path = UIBezierPath(arcCenter: .zero, radius: 20, startAngle: CGFloat.pi, endAngle: 0, clockwise: true)
+            node = SKShapeNode(path: path.cgPath)
+            node.fillColor = GamePalette.neonMagenta.withAlphaComponent(0.3)
+            node.strokeColor = GamePalette.neonMagenta
+        }
+        node.lineWidth = 4
+        node.glowWidth = 6
+        node.name = "powerup"
+        node.alpha = 0.85
+        node.physicsBody = SKPhysicsBody(circleOfRadius: 20)
+        node.physicsBody?.isDynamic = false
+        node.physicsBody?.categoryBitMask = PhysicsCategory.powerUp
+        node.physicsBody?.collisionBitMask = 0
+        node.physicsBody?.contactTestBitMask = PhysicsCategory.player
+
+        let aura = SKEmitterNode()
+        aura.particleTexture = makeParticleTexture(radius: 6, color: node.strokeColor) ?? SKTexture()
+        aura.particleBirthRate = 25
+        aura.particleLifetime = 1.0
+        aura.particleAlphaSpeed = -0.8
+        aura.particleScale = 0.4
+        aura.particleScaleSpeed = 0.2
+        aura.particleColor = node.strokeColor
+        aura.particleSpeed = 10
+        aura.targetNode = node
+        node.addChild(aura)
+        return node
+    }
+
+    public func makeButtonNode(text: String, size: CGSize) -> SKSpriteNode {
+        let texture = gradientTexture(size: size, colors: [GamePalette.neonMagenta, GamePalette.cyan])
+        let node = SKSpriteNode(texture: texture)
+        node.size = size
+        node.colorBlendFactor = 0
+        node.name = text
+
+        let label = SKLabelNode(text: text)
+        label.fontName = buttonFont.fontName
+        label.fontSize = 20
+        label.verticalAlignmentMode = .center
+        label.horizontalAlignmentMode = .center
+        label.fontColor = .white
+        label.name = "label"
+        node.addChild(label)
+
+        let pressedTexture = gradientTexture(size: size, colors: [GamePalette.cyan, GamePalette.royalBlue])
+        node.userData = ["pressedTexture": pressedTexture, "originalTexture": texture]
+        return node
+    }
+
+    public func makeParticleTexture(radius: CGFloat, color: UIColor) -> SKTexture? {
+        let size = CGSize(width: radius * 2 + 2, height: radius * 2 + 2)
+        UIGraphicsBeginImageContextWithOptions(size, false, UIScreen.main.scale)
+        guard let context = UIGraphicsGetCurrentContext() else { return nil }
+        let rect = CGRect(origin: .zero, size: size)
+        context.setFillColor(color.cgColor)
+        context.fillEllipse(in: rect)
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image.map(SKTexture.init)
+    }
+
+    private func gradientTexture(size: CGSize, colors: [UIColor]) -> SKTexture {
+        let width = Int(size.width)
+        let height = Int(size.height)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let context = CGContext(data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: width * 4, space: colorSpace, bitmapInfo: bitmapInfo) else {
+            return SKTexture()
+        }
+        let gradientColors = colors.map { $0.cgColor } as CFArray
+        guard let gradient = CGGradient(colorsSpace: colorSpace, colors: gradientColors, locations: nil) else {
+            return SKTexture()
+        }
+        context.drawLinearGradient(gradient, start: CGPoint(x: 0, y: 0), end: CGPoint(x: 0, y: size.height), options: [])
+        guard let image = context.makeImage() else { return SKTexture() }
+        return SKTexture(cgImage: image)
+    }
+}
+
+public extension SKSpriteNode {
+    func setPressed(_ pressed: Bool) {
+        guard let pressedTexture = userData?["pressedTexture"] as? SKTexture else { return }
+        if pressed {
+            userData?["originalTexture"] = self.texture
+            self.texture = pressedTexture
+        } else if let original = userData?["originalTexture"] as? SKTexture {
+            self.texture = original
+        }
+    }
+}

--- a/OrbitFlipFrenzy/GameConstants.swift
+++ b/OrbitFlipFrenzy/GameConstants.swift
@@ -1,0 +1,59 @@
+import Foundation
+import UIKit
+import CoreGraphics
+
+public struct GameConstants {
+    public static let baseSpeed: CGFloat = 100.0
+    public static let speedMultiplier: CGFloat = 1.02
+    public static let minimumSpawnRate: TimeInterval = 0.6
+    public static let baseSpawnRate: TimeInterval = 1.5
+    public static let spawnRateReductionPerLevel: TimeInterval = 0.05
+    public static let doubleFlipHoldThreshold: TimeInterval = 0.35
+    public static let doubleFlipReleaseWindow: TimeInterval = 0.2
+    public static let tapCooldown: TimeInterval = 0.15
+    public static let nearMissDistance: CGFloat = 12.0
+    public static let nearMissMultiplierGain: CGFloat = 0.2
+    public static let multiplierDecayFactor: CGFloat = 0.5
+    public static let scorePerAction: CGFloat = 10.0
+    public static let powerupShieldDuration: TimeInterval = 3.0
+    public static let powerupSlowFactor: CGFloat = 0.5
+    public static let magnetStrength: CGFloat = 50.0
+    public static let tutorialGhostObstacles: Int = 3
+    public static let maxRings: Int = 3
+    public static let ringRadii: [CGFloat] = [90.0, 140.0, 190.0]
+    public static let ringStrokeWidth: CGFloat = 6.0
+    public static let frameCaptureInterval: TimeInterval = 0.1
+    public static let replayDuration: TimeInterval = 3.0
+    public static let particleBirthRate: CGFloat = 100.0
+    public static let particleLifetime: CGFloat = 0.5
+    public static let milestoneScores: [Int] = [10, 25, 50, 100]
+    public static let milestoneStep: Int = 100
+    public static let inversionDuration: TimeInterval = 5.0
+    public static let meteorShowerDuration: TimeInterval = 6.0
+    public static let gravityReversalDuration: TimeInterval = 8.0
+    public static let magnetSafeZoneRadius: CGFloat = 24.0
+}
+
+public enum GamePalette {
+    public static let deepNavy = UIColor(hex: "0F172A")
+    public static let royalBlue = UIColor(hex: "1E3A8A")
+    public static let neonMagenta = UIColor(hex: "F472B6")
+    public static let cyan = UIColor(hex: "22D3EE")
+    public static let solarGold = UIColor(hex: "FBBF24")
+}
+
+public extension UIColor {
+    convenience init(hex: String, alpha: CGFloat = 1.0) {
+        var sanitized = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        if sanitized.count == 3 {
+            let chars = Array(sanitized)
+            sanitized = "" + String(chars[0]) + String(chars[0]) + String(chars[1]) + String(chars[1]) + String(chars[2]) + String(chars[2])
+        }
+        var value: UInt64 = 0
+        Scanner(string: sanitized).scanHexInt64(&value)
+        let r = CGFloat((value >> 16) & 0xFF) / 255.0
+        let g = CGFloat((value >> 8) & 0xFF) / 255.0
+        let b = CGFloat(value & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b, alpha: alpha)
+    }
+}

--- a/OrbitFlipFrenzy/GameData.swift
+++ b/OrbitFlipFrenzy/GameData.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+public struct DailyStreak: Codable {
+    public var streakDays: Int
+    public var lastDate: Date
+    public var multiplierActiveUntil: Date?
+
+    public init(streakDays: Int = 1, lastDate: Date = Date(), multiplierActiveUntil: Date? = nil) {
+        self.streakDays = streakDays
+        self.lastDate = lastDate
+        self.multiplierActiveUntil = multiplierActiveUntil
+    }
+
+    public var reward: Double {
+        return 50.0 * pow(1.5, Double(max(streakDays - 1, 0)))
+    }
+
+    public var multiplierBonus: Double { 1.1 }
+
+    public var isMultiplierActive: Bool {
+        guard let until = multiplierActiveUntil else { return false }
+        return Date() <= until
+    }
+}
+
+public final class GameData {
+    public static let shared = GameData()
+
+    private enum Keys {
+        static let highScore = "com.orbitflip.highscore"
+        static let gems = "com.orbitflip.gems"
+        static let streak = "com.orbitflip.streak"
+        static let lastStarterPackPrompt = "com.orbitflip.starterpack.prompt"
+    }
+
+    private let defaults: UserDefaults
+
+    private init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        bootstrapStreakIfNeeded()
+    }
+
+    public var highScore: Int {
+        get { defaults.integer(forKey: Keys.highScore) }
+        set { defaults.set(newValue, forKey: Keys.highScore) }
+    }
+
+    public var gems: Int {
+        get { defaults.integer(forKey: Keys.gems) }
+        set { defaults.set(newValue, forKey: Keys.gems) }
+    }
+
+    public var dailyStreak: DailyStreak {
+        get {
+            guard let data = defaults.data(forKey: Keys.streak),
+                  let streak = try? JSONDecoder().decode(DailyStreak.self, from: data) else {
+                return DailyStreak(streakDays: 1, lastDate: Date(), multiplierActiveUntil: nil)
+            }
+            return streak
+        }
+        set {
+            if let data = try? JSONEncoder().encode(newValue) {
+                defaults.set(data, forKey: Keys.streak)
+            }
+        }
+    }
+
+    public func registerDailyPlay() -> DailyStreak {
+        var streak = dailyStreak
+        let calendar = Calendar.current
+        if calendar.isDateInToday(streak.lastDate) {
+            return streak
+        }
+        if calendar.isDateInYesterday(streak.lastDate) {
+            streak.streakDays += 1
+        } else if !calendar.isDateInToday(streak.lastDate) {
+            streak.streakDays = 1
+        }
+        streak.lastDate = Date()
+        streak.multiplierActiveUntil = Calendar.current.date(byAdding: .hour, value: 24, to: Date())
+        dailyStreak = streak
+        gems += Int(streak.reward)
+        return streak
+    }
+
+    public func consumeMultiplierBonus() {
+        var streak = dailyStreak
+        streak.multiplierActiveUntil = nil
+        dailyStreak = streak
+    }
+
+    private func bootstrapStreakIfNeeded() {
+        if defaults.data(forKey: Keys.streak) == nil {
+            dailyStreak = DailyStreak(streakDays: 1, lastDate: Date())
+        }
+    }
+
+    public func shouldOfferStarterPack() -> Bool {
+        guard let lastPrompt = defaults.object(forKey: Keys.lastStarterPackPrompt) as? Date else {
+            return true
+        }
+        return Date().timeIntervalSince(lastPrompt) > 24 * 60 * 60
+    }
+
+    public func markStarterPackPrompted() {
+        defaults.set(Date(), forKey: Keys.lastStarterPackPrompt)
+    }
+}

--- a/OrbitFlipFrenzy/GameOverScene.swift
+++ b/OrbitFlipFrenzy/GameOverScene.swift
@@ -1,0 +1,195 @@
+import Foundation
+import SpriteKit
+import UIKit
+
+public protocol GameOverSceneDelegate: AnyObject {
+    func gameOverSceneDidRequestRetry(_ scene: GameOverScene)
+    func gameOverSceneDidRequestRevive(_ scene: GameOverScene)
+    func gameOverSceneDidFinishShare(_ scene: GameOverScene)
+    func gameOverSceneDidReturnHome(_ scene: GameOverScene)
+}
+
+public struct Challenge {
+    public let seed: UInt32
+    public let targetScore: Int
+
+    public init(seed: UInt32 = arc4random(), targetScore: Int) {
+        self.seed = seed
+        self.targetScore = targetScore
+    }
+
+    public func generateLink() -> String {
+        "orbitflip://challenge?seed=\(seed)&score=\(targetScore)"
+    }
+}
+
+public final class GameOverScene: SKScene {
+
+    public final class ViewModel {
+        private let assets: AssetGenerating
+        private let adManager: AdManaging
+        private let sound: SoundPlaying
+        private let haptics: HapticProviding
+        private let analytics: AnalyticsTracking
+
+        init(assets: AssetGenerating,
+             adManager: AdManaging,
+             sound: SoundPlaying,
+             haptics: HapticProviding,
+             analytics: AnalyticsTracking) {
+            self.assets = assets
+            self.adManager = adManager
+            self.sound = sound
+            self.haptics = haptics
+            self.analytics = analytics
+        }
+
+        func makeButton(title: String, size: CGSize) -> SKSpriteNode {
+            assets.makeButtonNode(text: title, size: size)
+        }
+
+        func showRewarded(from controller: UIViewController, completion: @escaping () -> Void) {
+            adManager.showRewardedAd(from: controller) { [weak self] in
+                self?.analytics.track(.adWatched(placement: "continue"))
+                completion()
+            }
+        }
+
+        func playCollisionFeedback() {
+            haptics.collision()
+            sound.play(.collision)
+        }
+
+        func share(result: GameResult, from controller: UIViewController) {
+            analytics.track(.shareInitiated)
+            var items: [Any] = ["I flipped out at \(result.score)! 🚀"]
+            if let data = result.replayData {
+                let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("orbitflip.gif")
+                try? data.write(to: tempURL)
+                items.append(tempURL)
+            }
+            let activity = UIActivityViewController(activityItems: items, applicationActivities: nil)
+            controller.present(activity, animated: true)
+        }
+
+        var rewardedReady: Bool { adManager.isRewardedReady }
+    }
+
+    public weak var overDelegate: GameOverSceneDelegate?
+
+    private let viewModel: ViewModel
+    private let assets: AssetGenerating
+    private var result: GameResult
+    private var shareButton: SKSpriteNode?
+    private var retryButton: SKSpriteNode?
+    private var continueButton: SKSpriteNode?
+    private var homeButton: SKSpriteNode?
+
+    public init(size: CGSize, viewModel: ViewModel, assets: AssetGenerating, result: GameResult) {
+        self.viewModel = viewModel
+        self.assets = assets
+        self.result = result
+        super.init(size: size)
+        scaleMode = .resizeFill
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func didMove(to view: SKView) {
+        anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        backgroundColor = GamePalette.deepNavy
+        addChild(assets.makeBackground(size: view.bounds.size))
+        viewModel.playCollisionFeedback()
+
+        let title = SKLabelNode(text: "Don't lose your streak!")
+        title.fontName = "Orbitron-Bold"
+        title.fontSize = 28
+        title.fontColor = GamePalette.solarGold
+        title.position = CGPoint(x: 0, y: view.bounds.height * 0.2)
+        addChild(title)
+
+        let scoreNode = SKLabelNode(text: "Score \(result.score)")
+        scoreNode.fontName = "Orbitron-Bold"
+        scoreNode.fontSize = 40
+        scoreNode.fontColor = .white
+        scoreNode.position = CGPoint(x: 0, y: title.position.y - 80)
+        addChild(scoreNode)
+
+        let statsNode = SKLabelNode(text: "Near-misses: \(result.nearMisses) • Time: \(String(format: "%.1fs", result.duration))")
+        statsNode.fontName = "SFProRounded-Bold"
+        statsNode.fontColor = GamePalette.cyan
+        statsNode.fontSize = 18
+        statsNode.position = CGPoint(x: 0, y: scoreNode.position.y - 40)
+        addChild(statsNode)
+
+        let eventsText = result.triggeredEvents.sorted().map { "#\($0)" }.joined(separator: " ")
+        if !eventsText.isEmpty {
+            let eventsLabel = SKLabelNode(text: "Moments unlocked: \(eventsText)")
+            eventsLabel.fontName = "SFProRounded-Bold"
+            eventsLabel.fontColor = GamePalette.neonMagenta
+            eventsLabel.fontSize = 16
+            eventsLabel.position = CGPoint(x: 0, y: statsNode.position.y - 40)
+            addChild(eventsLabel)
+        }
+
+        shareButton = viewModel.makeButton(title: "Share Highlight", size: CGSize(width: 220, height: 60))
+        shareButton?.position = CGPoint(x: 0, y: -20)
+        shareButton?.name = "share"
+        if let shareButton { addChild(shareButton) }
+
+        continueButton = viewModel.makeButton(title: "Watch to Continue", size: CGSize(width: 240, height: 60))
+        continueButton?.position = CGPoint(x: 0, y: shareButton?.position.y ?? -20 - 80)
+        continueButton?.name = "continue"
+        if let continueButton { addChild(continueButton) }
+        continueButton?.alpha = viewModel.rewardedReady ? 1.0 : 0.4
+
+        retryButton = viewModel.makeButton(title: "Retry", size: CGSize(width: 180, height: 60))
+        retryButton?.position = CGPoint(x: 0, y: (continueButton?.position.y ?? -100) - 80)
+        retryButton?.name = "retry"
+        if let retryButton { addChild(retryButton) }
+
+        homeButton = viewModel.makeButton(title: "Home", size: CGSize(width: 160, height: 54))
+        homeButton?.position = CGPoint(x: 0, y: (retryButton?.position.y ?? -180) - 70)
+        homeButton?.name = "home"
+        if let homeButton { addChild(homeButton) }
+
+        let challenge = Challenge(targetScore: result.score)
+        let challengeLabel = SKLabelNode(text: "Challenge friends: \(challenge.generateLink())")
+        challengeLabel.fontName = "SFProRounded-Regular"
+        challengeLabel.fontColor = UIColor.white.withAlphaComponent(0.7)
+        challengeLabel.fontSize = 12
+        challengeLabel.position = CGPoint(x: 0, y: (homeButton?.position.y ?? -240) - 50)
+        addChild(challengeLabel)
+    }
+
+    public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let location = touches.first?.location(in: self) else { return }
+        let nodes = nodes(at: location)
+        if let share = shareButton, nodes.contains(share) || nodes.contains(where: { $0.name == "label" && $0.parent == share }) {
+            handleShare()
+        } else if let retry = retryButton, nodes.contains(retry) || nodes.contains(where: { $0.name == "label" && $0.parent == retry }) {
+            overDelegate?.gameOverSceneDidRequestRetry(self)
+        } else if let home = homeButton, nodes.contains(home) || nodes.contains(where: { $0.name == "label" && $0.parent == home }) {
+            overDelegate?.gameOverSceneDidReturnHome(self)
+        } else if let cont = continueButton, nodes.contains(cont) || nodes.contains(where: { $0.name == "label" && $0.parent == cont }) {
+            handleContinue()
+        }
+    }
+
+    private func handleShare() {
+        guard let view = view, let controller = view.window?.rootViewController else { return }
+        viewModel.share(result: result, from: controller)
+        overDelegate?.gameOverSceneDidFinishShare(self)
+    }
+
+    private func handleContinue() {
+        guard viewModel.rewardedReady, let view = view, let controller = view.window?.rootViewController else { return }
+        continueButton?.alpha = 0.4
+        viewModel.showRewarded(from: controller) { [weak self] in
+            guard let self else { return }
+            self.overDelegate?.gameOverSceneDidRequestRevive(self)
+        }
+    }
+}

--- a/OrbitFlipFrenzy/GameScene.swift
+++ b/OrbitFlipFrenzy/GameScene.swift
@@ -1,0 +1,793 @@
+import Foundation
+import SpriteKit
+import UIKit
+import MobileCoreServices
+import ImageIO
+
+public protocol GameSceneDelegate: AnyObject {
+    func gameSceneDidEnd(_ scene: GameScene, result: GameResult)
+}
+
+public struct GameResult {
+    public let score: Int
+    public let duration: TimeInterval
+    public let nearMisses: Int
+    public let replayData: Data?
+    public let triggeredEvents: [Int]
+}
+
+public final class GameScene: SKScene, SKPhysicsContactDelegate {
+
+    // MARK: - Nested Types
+
+    private final class RingContainer {
+        let node: SKNode
+        let ring: SKShapeNode
+        let radius: CGFloat
+        var angularVelocity: CGFloat
+        let direction: CGFloat
+
+        init(node: SKNode, ring: SKShapeNode, radius: CGFloat, direction: CGFloat) {
+            self.node = node
+            self.ring = ring
+            self.radius = radius
+            self.direction = direction
+            self.angularVelocity = 0
+        }
+    }
+
+    public final class ViewModel {
+        private(set) var score: Int = 0
+        private(set) var currentMultiplier: CGFloat = 1.0
+        private(set) var level: Int = 1
+        private var scoreActions: Int = 0
+        private var milestoneSet: Set<Int>
+        private let analytics: AnalyticsTracking
+        private let data: GameData
+        private let startDate = Date()
+        private let sound: SoundPlaying
+        private let haptics: HapticProviding
+        private(set) var nearMisses: Int = 0
+
+        init(analytics: AnalyticsTracking,
+             data: GameData,
+             sound: SoundPlaying,
+             haptics: HapticProviding) {
+            self.analytics = analytics
+            self.data = data
+            self.sound = sound
+            self.haptics = haptics
+            self.milestoneSet = Set(GameConstants.milestoneScores)
+        }
+
+        var elapsedTime: TimeInterval { Date().timeIntervalSince(startDate) }
+
+        func reset() {
+            score = 0
+            currentMultiplier = 1.0
+            level = 1
+            scoreActions = 0
+            nearMisses = 0
+            milestoneSet = Set(GameConstants.milestoneScores)
+        }
+
+        func handleNearMiss() {
+            nearMisses += 1
+            currentMultiplier += GameConstants.nearMissMultiplierGain
+            haptics.nearMiss()
+            analytics.track(.nearMiss(count: nearMisses))
+        }
+
+        @discardableResult
+        func handleSafePass() -> Int {
+            scoreActions += 1
+            let points = Int(GameConstants.scorePerAction * currentMultiplier)
+            score += points
+            currentMultiplier = max(1.0, currentMultiplier * GameConstants.multiplierDecayFactor)
+            if scoreActions % 20 == 0 {
+                level += 1
+            }
+            checkMilestones()
+            return points
+        }
+
+        func currentSpeed() -> CGFloat {
+            GameConstants.baseSpeed * pow(GameConstants.speedMultiplier, CGFloat(max(level - 1, 0)))
+        }
+
+        func currentSpawnRate() -> TimeInterval {
+            max(GameConstants.minimumSpawnRate,
+                GameConstants.baseSpawnRate - (TimeInterval(level - 1) * GameConstants.spawnRateReductionPerLevel))
+        }
+
+        private func checkMilestones() {
+            if milestoneSet.contains(score) {
+                milestoneSet.remove(score)
+                let nextMilestone = score + GameConstants.milestoneStep
+                milestoneSet.insert(nextMilestone)
+                sound.play(.milestone)
+                haptics.milestone()
+            }
+        }
+
+        func registerStart() {
+            analytics.track(.gameStart(level: level))
+            sound.play(.gameStart)
+        }
+
+        func registerCollision() {
+            analytics.track(.gameOver(score: score, duration: elapsedTime))
+            haptics.collision()
+            sound.play(.collision)
+        }
+
+        func registerFlip() {
+            sound.play(.playerFlip)
+            haptics.playerAction()
+        }
+
+        func registerPowerup(_ powerup: PowerUp) {
+            analytics.track(.powerupUsed(type: powerup))
+            sound.play(.powerupCollect)
+        }
+
+        func finalizeScore() {
+            if score > data.highScore {
+                data.highScore = score
+            }
+        }
+    }
+
+    private final class ObstaclePool {
+        private var available: [SKShapeNode] = []
+        private var active: Set<SKShapeNode> = []
+        private let assetGenerator: AssetGenerating
+
+        init(assetGenerator: AssetGenerating) {
+            self.assetGenerator = assetGenerator
+        }
+
+        func spawn() -> SKShapeNode {
+            let node: SKShapeNode
+            if let reused = available.popLast() {
+                node = reused
+            } else {
+                node = assetGenerator.makeObstacleNode(size: CGSize(width: 36, height: 42))
+            }
+            node.alpha = 1.0
+            node.isHidden = false
+            node.userData = NSMutableDictionary()
+            active.insert(node)
+            return node
+        }
+
+        func recycle(_ node: SKShapeNode) {
+            node.removeAllActions()
+            node.removeFromParent()
+            node.userData?.removeAllObjects()
+            active.remove(node)
+            available.append(node)
+        }
+
+        func allActive() -> [SKShapeNode] {
+            Array(active)
+        }
+    }
+
+    public final class ReplayRecorder {
+        private struct Frame {
+            let texture: SKTexture
+            let timestamp: TimeInterval
+        }
+
+        private var frames: [Frame] = []
+        private var accumulator: TimeInterval = 0
+
+        public init() {}
+
+        public func update(deltaTime: TimeInterval, scene: SKScene) {
+            accumulator += deltaTime
+            guard accumulator >= GameConstants.frameCaptureInterval else { return }
+            accumulator = 0
+            guard let view = scene.view,
+                  let texture = view.texture(from: scene) else { return }
+            let timestamp = CACurrentMediaTime()
+            frames.append(Frame(texture: texture, timestamp: timestamp))
+            purgeOldFrames(reference: timestamp)
+        }
+
+        private func purgeOldFrames(reference: TimeInterval) {
+            let threshold = reference - GameConstants.replayDuration
+            frames.removeAll { $0.timestamp < threshold }
+        }
+
+        public func generateGIF() -> Data? {
+            guard !frames.isEmpty else { return nil }
+            let frameDelay = GameConstants.frameCaptureInterval
+            let data = NSMutableData()
+            guard let destination = CGImageDestinationCreateWithData(data, kUTTypeGIF, frames.count, nil) else { return nil }
+            let loopDict = [kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFLoopCount: 0]] as CFDictionary
+            CGImageDestinationSetProperties(destination, loopDict)
+            for frame in frames {
+                guard let cgImage = frame.texture.cgImage() else { continue }
+                let frameDict = [kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFDelayTime: frameDelay]] as CFDictionary
+                CGImageDestinationAddImage(destination, cgImage, frameDict)
+            }
+            CGImageDestinationFinalize(destination)
+            return data as Data
+        }
+    }
+
+    // MARK: - Properties
+
+    public weak var gameDelegate: GameSceneDelegate?
+
+    private let viewModel: ViewModel
+    private let assets: AssetGenerating
+    private let sound: SoundPlaying
+    private let haptics: HapticProviding
+    private let powerups: PowerupManager
+    private let obstaclePool: ObstaclePool
+    private let replayRecorder = ReplayRecorder()
+
+    private var backgroundNode: SKSpriteNode?
+    private var ringContainers: [RingContainer] = []
+    private var playerNode: SKShapeNode!
+    private var ghostNode: SKShapeNode?
+    private var socialProofLabel: SKLabelNode?
+
+    private var lastUpdate: TimeInterval = 0
+    private var spawnTimer: TimeInterval = 0
+    private var specialEventsTriggered: Set<Int> = []
+    private var isGameOver = false
+
+    private var lastTapTime: TimeInterval = 0
+    private var touchBeganTime: TimeInterval?
+    private var doubleFlipArmed = false
+    private var doubleFlipReadyTime: TimeInterval = 0
+    private var activeRingCount = 1
+    private var tutorialObstaclesRemaining = GameConstants.tutorialGhostObstacles
+
+    private var meteorShowerEnds: TimeInterval = 0
+    private var inversionEnds: TimeInterval = 0
+    private var gravityEnds: TimeInterval = 0
+    private var ringDirections: [CGFloat] = [1, -1, 1]
+
+    private var powerUpNodes: [SKShapeNode] = []
+
+    private var currentTimeSnapshot: TimeInterval = 0
+
+    // MARK: - Initialization
+
+    public init(size: CGSize,
+                viewModel: ViewModel,
+                assets: AssetGenerating,
+                sound: SoundPlaying,
+                haptics: HapticProviding,
+                powerups: PowerupManager) {
+        self.viewModel = viewModel
+        self.assets = assets
+        self.sound = sound
+        self.haptics = haptics
+        self.powerups = powerups
+        self.obstaclePool = ObstaclePool(assetGenerator: assets)
+        super.init(size: size)
+        scaleMode = .resizeFill
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Scene Lifecycle
+
+    public override func didMove(to view: SKView) {
+        physicsWorld.gravity = .zero
+        physicsWorld.contactDelegate = self
+        anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        backgroundColor = GamePalette.deepNavy
+
+        let background = assets.makeBackground(size: view.bounds.size)
+        addChild(background)
+        backgroundNode = background
+
+        configureRings()
+        configurePlayer()
+        configureGhost()
+        configureSocialProof()
+
+        viewModel.reset()
+        viewModel.registerStart()
+        specialEventsTriggered.removeAll()
+    }
+
+    private func configureRings() {
+        ringContainers.removeAll()
+        for (index, radius) in GameConstants.ringRadii.enumerated() {
+            let container = SKNode()
+            container.zPosition = CGFloat(index) - 1
+            let color = index % 2 == 0 ? GamePalette.cyan : GamePalette.neonMagenta
+            let ring = assets.makeRingNode(radius: radius,
+                                           lineWidth: GameConstants.ringStrokeWidth,
+                                           color: color,
+                                           glow: 10)
+            container.addChild(ring)
+            addChild(container)
+            ringContainers.append(RingContainer(node: container, ring: ring, radius: radius, direction: ringDirections[index]))
+            container.alpha = index == 0 ? 1.0 : 0.0
+        }
+        activeRingCount = 1
+    }
+
+    private func configurePlayer() {
+        playerNode = assets.makePlayerNode()
+        guard let firstRing = ringContainers.first else { return }
+        firstRing.node.addChild(playerNode)
+        playerNode.position = CGPoint(x: firstRing.radius, y: 0)
+    }
+
+    private func configureGhost() {
+        let ghost = SKShapeNode(circleOfRadius: 32)
+        ghost.fillColor = GamePalette.solarGold.withAlphaComponent(0.1)
+        ghost.strokeColor = GamePalette.solarGold
+        ghost.lineWidth = 2
+        ghost.alpha = 0.3
+        ghost.zPosition = 5
+        ghost.name = "ghost"
+        addChild(ghost)
+        ghostNode = ghost
+        ghost.isHidden = false
+    }
+
+    private func configureSocialProof() {
+        let names = ["Sarah", "Alex", "Priya", "Noah", "Luna", "Kai"]
+        let name = names.randomElement() ?? "Sarah"
+        let label = SKLabelNode(text: "\(name) just beat your score! Reclaim it?")
+        label.fontName = "SFProRounded-Bold"
+        label.fontSize = 16
+        label.fontColor = GamePalette.neonMagenta
+        label.position = CGPoint(x: 0, y: size.height * 0.35)
+        label.alpha = 0
+        addChild(label)
+        socialProofLabel = label
+        let sequence = SKAction.sequence([
+            SKAction.wait(forDuration: 5.0),
+            SKAction.fadeIn(withDuration: 0.5),
+            SKAction.wait(forDuration: 2.5),
+            SKAction.fadeOut(withDuration: 0.5)
+        ])
+        label.run(SKAction.repeatForever(sequence))
+    }
+
+    // MARK: - Touch Handling
+
+    public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard !isGameOver else { return }
+        touchBeganTime = currentTimeSnapshot
+        doubleFlipArmed = false
+    }
+
+    public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard !isGameOver, let start = touchBeganTime else { return }
+        if !doubleFlipArmed && currentTimeSnapshot - start >= GameConstants.doubleFlipHoldThreshold {
+            doubleFlipArmed = true
+            doubleFlipReadyTime = currentTimeSnapshot
+        }
+    }
+
+    public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard !isGameOver else { return }
+        defer { touchBeganTime = nil }
+        let now = currentTimeSnapshot
+        if doubleFlipArmed && now - doubleFlipReadyTime <= GameConstants.doubleFlipReleaseWindow {
+            performFlip(doubleJump: true)
+        } else {
+            performFlip(doubleJump: false)
+        }
+    }
+
+    private func performFlip(doubleJump: Bool) {
+        guard currentTimeSnapshot - lastTapTime >= GameConstants.tapCooldown else { return }
+        guard let parent = playerNode.parent, let currentIndex = ringContainers.firstIndex(where: { $0.node == parent }) else { return }
+        var step = doubleJump ? 2 : 1
+        if currentIndex >= activeRingCount - 1 {
+            step = -step
+        }
+        var targetIndex = currentIndex + step
+        if targetIndex < 0 {
+            targetIndex = min(activeRingCount - 1, currentIndex + abs(step))
+        } else if targetIndex >= activeRingCount {
+            targetIndex = max(0, currentIndex - abs(step))
+        }
+        guard targetIndex != currentIndex else { return }
+        let targetRing = ringContainers[targetIndex]
+        let converted = parent.convert(playerNode.position, to: self)
+        let local = convert(converted, to: targetRing.node)
+        playerNode.removeFromParent()
+        targetRing.node.addChild(playerNode)
+        let destination = local.normalized(to: targetRing.radius)
+        playerNode.position = destination
+        let move = SKAction.move(to: destination, duration: 0.12)
+        move.timingMode = .easeInEaseOut
+        playerNode.run(move)
+        lastTapTime = currentTimeSnapshot
+        viewModel.registerFlip()
+        if doubleJump {
+            sound.play(.nearMiss)
+        }
+    }
+
+    // MARK: - Update Loop
+
+    public override func update(_ currentTime: TimeInterval) {
+        if lastUpdate == 0 { lastUpdate = currentTime }
+        let delta = currentTime - lastUpdate
+        lastUpdate = currentTime
+        currentTimeSnapshot = currentTime
+        guard !isGameOver else { return }
+
+        if let start = touchBeganTime, !doubleFlipArmed && currentTime - start >= GameConstants.doubleFlipHoldThreshold {
+            doubleFlipArmed = true
+            doubleFlipReadyTime = currentTime
+        }
+
+        if gravityEnds > 0 && currentTime >= gravityEnds {
+            gravityEnds = 0
+        }
+        if meteorShowerEnds > 0 && currentTime >= meteorShowerEnds {
+            meteorShowerEnds = 0
+        }
+        if inversionEnds > 0 && currentTime >= inversionEnds {
+            inversionEnds = 0
+        }
+
+        replayRecorder.update(deltaTime: delta, scene: self)
+
+        updateRings(delta: delta)
+        updateSpawn(delta: delta, currentTime: currentTime)
+        updateObstacles(currentTime: currentTime)
+        updatePowerups(currentTime: currentTime)
+        updateGhostFollowing()
+        applyMagnetIfNeeded()
+        handleSpecialEvents()
+    }
+
+    private func updateRings(delta: TimeInterval) {
+        var speed = viewModel.currentSpeed()
+        if powerups.isActive(.slowMo, currentTime: currentTimeSnapshot) {
+            speed *= GameConstants.powerupSlowFactor
+        }
+        for (index, container) in ringContainers.enumerated() {
+            guard index < activeRingCount else {
+                container.node.alpha = max(container.node.alpha - CGFloat(delta) * 2.0, 0.0)
+                continue
+            }
+            container.node.alpha = min(container.node.alpha + CGFloat(delta) * 2.0, 1.0)
+            let direction = gravityEnds > 0 && currentTimeSnapshot < gravityEnds ? -container.direction : container.direction
+            let angularVelocity = (speed / container.radius) * direction
+            container.node.zRotation += angularVelocity * CGFloat(delta)
+        }
+    }
+
+    private func updateSpawn(delta: TimeInterval, currentTime: TimeInterval) {
+        spawnTimer += delta
+        var spawnRate = meteorShowerEnds > currentTime ? max(0.2, viewModel.currentSpawnRate() * 0.6) : viewModel.currentSpawnRate()
+        if powerups.isActive(.slowMo, currentTime: currentTimeSnapshot) {
+            spawnRate *= 1.5
+        }
+        while spawnTimer >= spawnRate {
+            spawnTimer -= spawnRate
+            spawnObstacle(at: currentTime)
+        }
+    }
+
+    private func spawnObstacle(at time: TimeInterval, colorOverride: UIColor? = nil) {
+        guard let (ring, index) = availableRingForSpawn() else { return }
+        let obstacle = obstaclePool.spawn()
+        let angle = CGFloat.random(in: 0...(2 * .pi))
+        obstacle.zRotation = angle
+        obstacle.position = CGPoint(x: cos(angle) * ring.radius, y: sin(angle) * ring.radius)
+        if let override = colorOverride {
+            obstacle.fillColor = override
+            obstacle.strokeColor = override
+        } else {
+            obstacle.fillColor = GamePalette.solarGold
+            obstacle.strokeColor = GamePalette.cyan
+        }
+        ring.node.addChild(obstacle)
+        obstacle.userData?["spawn"] = time
+        obstacle.userData?["near"] = false
+        obstacle.userData?["ringIndex"] = index
+        if tutorialObstaclesRemaining > 0 {
+            tutorialObstaclesRemaining -= 1
+            showGhostGuidance(for: obstacle, on: ring)
+        }
+        if Int.random(in: 0..<100) < 8 {
+            spawnPowerUp(on: ring, angle: angle + .pi / 4)
+        }
+    }
+
+    private func availableRingForSpawn() -> (RingContainer, Int)? {
+        adjustActiveRingsIfNeeded()
+        let rings = Array(ringContainers.prefix(activeRingCount))
+        guard !rings.isEmpty else { return nil }
+        let index = Int.random(in: 0..<rings.count)
+        return (rings[index], index)
+    }
+
+    private func adjustActiveRingsIfNeeded() {
+        let newActive: Int
+        if viewModel.level <= 3 {
+            newActive = 1
+        } else if viewModel.level <= 6 {
+            newActive = 2
+        } else {
+            newActive = GameConstants.maxRings
+        }
+        if newActive != activeRingCount {
+            activeRingCount = newActive
+        }
+    }
+
+    private func spawnPowerUp(on ring: RingContainer, angle: CGFloat) {
+        let typeRoll = Int.random(in: 0..<3)
+        let type: PowerUpType
+        switch typeRoll {
+        case 0: type = .shield
+        case 1: type = .slowMo
+        default: type = .magnet
+        }
+        let node = assets.makePowerUpNode(of: type)
+        node.position = CGPoint(x: cos(angle) * ring.radius, y: sin(angle) * ring.radius)
+        ring.node.addChild(node)
+        node.userData = ["spawn": currentTimeSnapshot, "type": type.rawValue]
+        powerUpNodes.append(node)
+    }
+
+    private func updateObstacles(currentTime: TimeInterval) {
+        for obstacle in obstaclePool.allActive() {
+            guard let spawnTime = obstacle.userData?["spawn"] as? TimeInterval else { continue }
+            if currentTime - spawnTime > 6.0 {
+                obstacleCleared(obstacle)
+                continue
+            }
+            handleNearMissCheck(for: obstacle)
+        }
+    }
+
+    private func obstacleCleared(_ obstacle: SKShapeNode) {
+        _ = viewModel.handleSafePass()
+        obstaclePool.recycle(obstacle)
+    }
+
+    private func handleNearMissCheck(for obstacle: SKShapeNode) {
+        let playerPosition = playerNode.parent?.convert(playerNode.position, to: self) ?? .zero
+        let obstaclePosition = obstacle.parent?.convert(obstacle.position, to: self) ?? .zero
+        let distance = hypot(playerPosition.x - obstaclePosition.x, playerPosition.y - obstaclePosition.y)
+        let alreadyNear = obstacle.userData?["near"] as? Bool ?? false
+        if distance < GameConstants.nearMissDistance && !alreadyNear {
+            obstacle.userData?["near"] = true
+            viewModel.handleNearMiss()
+            sound.play(.nearMiss)
+        }
+    }
+
+    private func updatePowerups(currentTime: TimeInterval) {
+        powerups.update(currentTime: currentTime)
+        for (index, node) in powerUpNodes.enumerated().reversed() {
+            let playerPosition = playerNode.parent?.convert(playerNode.position, to: self) ?? .zero
+            let nodePosition = node.parent?.convert(node.position, to: self) ?? .zero
+            let distance = hypot(playerPosition.x - nodePosition.x, playerPosition.y - nodePosition.y)
+            if distance < 36 {
+                applyPowerUp(node)
+                powerUpNodes.remove(at: index)
+            } else if let spawn = node.userData?["spawn"] as? TimeInterval, currentTime - spawn > 5.0 {
+                node.removeFromParent()
+                powerUpNodes.remove(at: index)
+            }
+        }
+    }
+
+    private func applyPowerUp(_ node: SKShapeNode) {
+        guard let type = determinePowerUpType(from: node) else { return }
+        node.removeFromParent()
+        let currentTime = currentTimeSnapshot
+        let powerUp: PowerUp
+        switch type {
+        case .shield:
+            powerUp = .shield(duration: GameConstants.powerupShieldDuration)
+        case .slowMo:
+            powerUp = .slowMo(factor: GameConstants.powerupSlowFactor, duration: GameConstants.powerupShieldDuration)
+        case .magnet:
+            powerUp = .magnet(strength: GameConstants.magnetStrength, duration: GameConstants.powerupShieldDuration)
+        }
+        powerups.activate(powerUp, currentTime: currentTime)
+        viewModel.registerPowerup(powerUp)
+    }
+
+    private func determinePowerUpType(from node: SKShapeNode) -> PowerUpType? {
+        guard let raw = node.userData?["type"] as? String,
+              let type = PowerUpType(rawValue: raw) else { return nil }
+        return type
+    }
+
+    private func updateGhostFollowing() {
+        guard let ghost = ghostNode, tutorialObstaclesRemaining > 0 else {
+            ghostNode?.removeFromParent()
+            ghostNode = nil
+            return
+        }
+        guard let ring = ringContainers.first else { return }
+        let angle = playerNode.parent?.convert(playerNode.position, to: ring.node) ?? .zero
+        let currentAngle = atan2(angle.y, angle.x)
+        let ghostTarget = CGPoint(x: cos(currentAngle) * (ring.radius + 30), y: sin(currentAngle) * (ring.radius + 30))
+        let action = SKAction.move(to: ghostTarget, duration: 0.3)
+        action.timingMode = .easeInEaseOut
+        ghost.run(action)
+    }
+
+    private func showGhostGuidance(for obstacle: SKShapeNode, on ring: RingContainer) {
+        guard let ghost = ghostNode else { return }
+        let obstaclePosition = obstacle.parent?.convert(obstacle.position, to: self) ?? .zero
+        let angle = atan2(obstaclePosition.y, obstaclePosition.x)
+        let safeAngle = angle + (.pi / 2)
+        let points = [CGPoint(x: cos(angle) * (ring.radius + 20), y: sin(angle) * (ring.radius + 20)),
+                      CGPoint(x: cos(safeAngle) * (ring.radius + 20), y: sin(safeAngle) * (ring.radius + 20))]
+        let path = CGMutablePath()
+        path.move(to: points[0])
+        path.addLine(to: points[1])
+        let follow = SKAction.follow(path, asOffset: false, orientToPath: false, duration: 0.6)
+        follow.timingMode = .easeInEaseOut
+        ghost.run(follow)
+    }
+
+    private func applyMagnetIfNeeded() {
+        guard powerups.isActive(.magnet, currentTime: currentTimeSnapshot) else { return }
+        let obstacles = obstaclePool.allActive()
+        guard !obstacles.isEmpty, let parent = playerNode.parent else { return }
+        let playerPosition = parent.convert(playerNode.position, to: self)
+        let nearest = obstacles.min(by: { lhs, rhs in
+            let left = lhs.parent?.convert(lhs.position, to: self) ?? .zero
+            let right = rhs.parent?.convert(rhs.position, to: self) ?? .zero
+            return playerPosition.distance(to: left) < playerPosition.distance(to: right)
+        })
+        guard let obstacle = nearest else { return }
+        let obstaclePosition = obstacle.parent?.convert(obstacle.position, to: self) ?? .zero
+        let safeAngle = atan2(obstaclePosition.y, obstaclePosition.x) + (.pi / 2)
+        let currentAngle = atan2(playerPosition.y, playerPosition.x)
+        let delta = shortestAngleBetween(currentAngle, safeAngle)
+        let adjustedAngle = currentAngle + delta * 0.08
+        let radius = playerPosition.length()
+        let newPosition = CGPoint(x: cos(adjustedAngle) * radius, y: sin(adjustedAngle) * radius)
+        playerNode.position = convert(newPosition, to: parent)
+    }
+
+    private func handleSpecialEvents() {
+        let score = viewModel.score
+        if score >= 69 && !specialEventsTriggered.contains(69) {
+            specialEventsTriggered.insert(69)
+            triggerColorInversion()
+        }
+        if score >= 420 && !specialEventsTriggered.contains(420) {
+            specialEventsTriggered.insert(420)
+            triggerMeteorShower()
+        }
+        if score >= 999 && !specialEventsTriggered.contains(999) {
+            specialEventsTriggered.insert(999)
+            triggerGravityReversal()
+        }
+    }
+
+    private func triggerColorInversion() {
+        inversionEnds = currentTimeSnapshot + GameConstants.inversionDuration
+        let invertAction = SKAction.customAction(withDuration: GameConstants.inversionDuration) { [weak self] _, elapsed in
+            guard let self else { return }
+            let progress = elapsed / CGFloat(GameConstants.inversionDuration)
+            self.backgroundNode?.color = UIColor.white.withAlphaComponent(progress)
+            self.backgroundNode?.colorBlendFactor = progress
+        }
+        backgroundNode?.run(SKAction.sequence([invertAction, SKAction.run { [weak self] in
+            self?.backgroundNode?.colorBlendFactor = 0
+        }]))
+    }
+
+    private func triggerMeteorShower() {
+        meteorShowerEnds = currentTimeSnapshot + GameConstants.meteorShowerDuration
+        for _ in 0..<10 {
+            let rainbow = UIColor(hue: CGFloat.random(in: 0...1), saturation: 0.9, brightness: 1.0, alpha: 1.0)
+            spawnObstacle(at: currentTimeSnapshot, colorOverride: rainbow)
+        }
+    }
+
+    private func triggerGravityReversal() {
+        gravityEnds = currentTimeSnapshot + GameConstants.gravityReversalDuration
+    }
+
+    // MARK: - Contact Handling
+
+    public func didBegin(_ contact: SKPhysicsContact) {
+        guard !isGameOver else { return }
+        let bodies = [contact.bodyA, contact.bodyB]
+        if bodies.contains(where: { $0.categoryBitMask == PhysicsCategory.obstacle }) &&
+            bodies.contains(where: { $0.categoryBitMask == PhysicsCategory.player }) {
+            handleCollision(withShieldCheck: powerups.isActive(.shield, currentTime: currentTimeSnapshot))
+        }
+        if bodies.contains(where: { $0.categoryBitMask == PhysicsCategory.powerUp }) &&
+            bodies.contains(where: { $0.categoryBitMask == PhysicsCategory.player }) {
+            if let powerUpNode = (bodies.first { $0.categoryBitMask == PhysicsCategory.powerUp }?.node) as? SKShapeNode {
+                applyPowerUp(powerUpNode)
+            }
+        }
+    }
+
+    private func handleCollision(withShieldCheck hasShield: Bool) {
+        if hasShield {
+            sound.play(.collision)
+            return
+        }
+        shake(intensity: 6.0)
+        endGame()
+    }
+
+    private func endGame() {
+        guard !isGameOver else { return }
+        isGameOver = true
+        viewModel.registerCollision()
+        viewModel.finalizeScore()
+        let result = GameResult(score: viewModel.score,
+                                duration: viewModel.elapsedTime,
+                                nearMisses: viewModel.nearMisses,
+                                replayData: replayRecorder.generateGIF(),
+                                triggeredEvents: Array(specialEventsTriggered))
+        gameDelegate?.gameSceneDidEnd(self, result: result)
+    }
+
+    // MARK: - Revive
+
+    public func revivePlayer(withShield: Bool) {
+        guard isGameOver else { return }
+        isGameOver = false
+        if withShield {
+            powerups.activate(.shield(duration: GameConstants.powerupShieldDuration), currentTime: currentTimeSnapshot)
+        }
+        spawnTimer = 0
+        specialEventsTriggered.removeAll()
+        obstaclePool.allActive().forEach { obstaclePool.recycle($0) }
+        lastTapTime = currentTimeSnapshot
+    }
+}
+
+private extension CGPoint {
+    func length() -> CGFloat {
+        sqrt(x * x + y * y)
+    }
+
+    func normalized(to radius: CGFloat) -> CGPoint {
+        let currentLength = length()
+        guard currentLength > 0 else { return CGPoint(x: radius, y: 0) }
+        let scale = radius / currentLength
+        return CGPoint(x: x * scale, y: y * scale)
+    }
+
+    func distance(to point: CGPoint) -> CGFloat {
+        hypot(point.x - x, point.y - y)
+    }
+}
+
+private func shortestAngleBetween(_ angle1: CGFloat, _ angle2: CGFloat) -> CGFloat {
+    var difference = angle2 - angle1
+    while difference > .pi { difference -= 2 * .pi }
+    while difference < -.pi { difference += 2 * .pi }
+    return difference
+}
+
+public extension SKScene {
+    func shake(intensity: CGFloat = 5.0) {
+        let sequence = SKAction.sequence([
+            SKAction.moveBy(x: intensity, y: 0, duration: 0.05),
+            SKAction.moveBy(x: -intensity * 2, y: 0, duration: 0.05),
+            SKAction.moveBy(x: intensity, y: 0, duration: 0.05)
+        ])
+        run(sequence)
+    }
+}

--- a/OrbitFlipFrenzy/GameViewController.swift
+++ b/OrbitFlipFrenzy/GameViewController.swift
@@ -1,0 +1,170 @@
+import Foundation
+import SpriteKit
+import SwiftUI
+import UIKit
+
+final class GameViewController: UIViewController {
+    private lazy var skView: SKView = {
+        let view = SKView(frame: UIScreen.main.bounds)
+        view.ignoresSiblingOrder = true
+        view.preferredFramesPerSecond = 60
+        return view
+    }()
+
+    private let container = DependencyContainer()
+    private var currentGameScene: GameScene?
+
+    override func loadView() {
+        view = skView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = GamePalette.deepNavy
+        presentMenu()
+    }
+
+    override var prefersStatusBarHidden: Bool { true }
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask { .portrait }
+
+    private func presentMenu() {
+        let scene = container.makeMenuScene(size: view.bounds.size)
+        scene.menuDelegate = self
+        skView.presentScene(scene, transition: .crossFade(withDuration: 0.5))
+    }
+
+    private func presentGame() {
+        let scene = container.makeGameScene(size: view.bounds.size)
+        scene.gameDelegate = self
+        currentGameScene = scene
+        skView.presentScene(scene, transition: .doorsOpenVertical(withDuration: 0.6))
+    }
+
+    private func presentGameOver(with result: GameResult) {
+        guard let gameScene = currentGameScene else { return }
+        gameScene.isPaused = true
+        let scene = container.makeGameOverScene(size: view.bounds.size, result: result)
+        scene.overDelegate = self
+        skView.presentScene(scene, transition: .crossFade(withDuration: 0.5))
+        currentGameScene = gameScene
+    }
+}
+
+extension GameViewController: MenuSceneDelegate {
+    func menuSceneDidStartGame(_ scene: MenuScene) {
+        presentGame()
+    }
+
+    func menuScene(_ scene: MenuScene, didSelectProduct name: String) {
+        container.presentPurchasePrompt(for: name, from: self)
+    }
+}
+
+extension GameViewController: GameSceneDelegate {
+    func gameSceneDidEnd(_ scene: GameScene, result: GameResult) {
+        currentGameScene = scene
+        presentGameOver(with: result)
+    }
+}
+
+extension GameViewController: GameOverSceneDelegate {
+    func gameOverSceneDidRequestRetry(_ scene: GameOverScene) {
+        presentGame()
+    }
+
+    func gameOverSceneDidRequestRevive(_ scene: GameOverScene) {
+        guard let gameScene = currentGameScene else { return }
+        gameScene.isPaused = false
+        skView.presentScene(gameScene, transition: .doorsOpenVertical(withDuration: 0.5))
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            gameScene.revivePlayer(withShield: true)
+        }
+    }
+
+    func gameOverSceneDidFinishShare(_ scene: GameOverScene) {
+        // No-op: analytics already handled in scene
+    }
+
+    func gameOverSceneDidReturnHome(_ scene: GameOverScene) {
+        presentMenu()
+    }
+}
+
+private final class DependencyContainer {
+    let assets = AssetGenerator()
+    let sound = SoundEngine()
+    let haptics = HapticManager()
+    let analytics = Analytics()
+    let adManager = AdManager()
+    let data = GameData.shared
+
+    func makeMenuScene(size: CGSize) -> MenuScene {
+        let viewModel = MenuScene.ViewModel(assets: assets, data: data, sound: sound)
+        let scene = MenuScene(size: size, viewModel: viewModel, assets: assets)
+        return scene
+    }
+
+    func makeGameScene(size: CGSize) -> GameScene {
+        let powerups = PowerupManager()
+        let viewModel = GameScene.ViewModel(analytics: analytics,
+                                            data: data,
+                                            sound: sound,
+                                            haptics: haptics)
+        let scene = GameScene(size: size,
+                              viewModel: viewModel,
+                              assets: assets,
+                              sound: sound,
+                              haptics: haptics,
+                              powerups: powerups)
+        return scene
+    }
+
+    func makeGameOverScene(size: CGSize, result: GameResult) -> GameOverScene {
+        let viewModel = GameOverScene.ViewModel(assets: assets,
+                                                adManager: adManager,
+                                                sound: sound,
+                                                haptics: haptics,
+                                                analytics: analytics)
+        let scene = GameOverScene(size: size, viewModel: viewModel, assets: assets, result: result)
+        return scene
+    }
+
+    func presentPurchasePrompt(for product: String, from controller: UIViewController) {
+        let message: String
+        switch product {
+        case "Starter Pack":
+            message = "Starter Pack unlocks Nova Pod skin + 200 gems for just $0.99!"
+        case "Remove Ads":
+            message = "Remove all ads and keep rewarded options for $2.99."
+        case "100 Gems":
+            message = "Grab 100 gems instantly for $0.99."
+        case "550 Gems":
+            message = "550 gems + bonus to customize your pod."
+        case "1200 Gems":
+            message = "1200 gems + massive bonus trails."
+        default:
+            message = product
+        }
+        let alert = UIAlertController(title: product, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        controller.present(alert, animated: true)
+    }
+}
+
+struct GameView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> GameViewController {
+        GameViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: GameViewController, context: Context) {}
+}
+
+@main
+struct OrbitFlipFrenzyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            GameView()
+                .edgesIgnoringSafeArea(.all)
+        }
+    }
+}

--- a/OrbitFlipFrenzy/HapticManager.swift
+++ b/OrbitFlipFrenzy/HapticManager.swift
@@ -1,0 +1,44 @@
+import Foundation
+import UIKit
+
+public protocol HapticProviding {
+    func playerAction()
+    func collision()
+    func milestone()
+    func nearMiss()
+}
+
+public final class HapticManager: HapticProviding {
+    private let lightGenerator = UIImpactFeedbackGenerator(style: .light)
+    private let mediumGenerator = UIImpactFeedbackGenerator(style: .medium)
+    private let notificationGenerator = UINotificationFeedbackGenerator()
+
+    public init() {
+        prepare()
+    }
+
+    public func prepare() {
+        lightGenerator.prepare()
+        mediumGenerator.prepare()
+        notificationGenerator.prepare()
+    }
+
+    public func playerAction() {
+        lightGenerator.impactOccurred(intensity: 0.3)
+    }
+
+    public func collision() {
+        notificationGenerator.notificationOccurred(.error)
+    }
+
+    public func milestone() {
+        mediumGenerator.impactOccurred(intensity: 0.8)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) { [weak self] in
+            self?.mediumGenerator.impactOccurred(intensity: 0.8)
+        }
+    }
+
+    public func nearMiss() {
+        lightGenerator.impactOccurred(intensity: 0.2)
+    }
+}

--- a/OrbitFlipFrenzy/MenuScene.swift
+++ b/OrbitFlipFrenzy/MenuScene.swift
@@ -1,0 +1,176 @@
+import Foundation
+import SpriteKit
+import UIKit
+
+public protocol MenuSceneDelegate: AnyObject {
+    func menuSceneDidStartGame(_ scene: MenuScene)
+    func menuScene(_ scene: MenuScene, didSelectProduct name: String)
+}
+
+public final class MenuScene: SKScene {
+
+    public final class ViewModel {
+        struct IAPProduct {
+            let title: String
+            let price: String
+            let description: String
+        }
+
+        private let assets: AssetGenerating
+        private let data: GameData
+        private let sound: SoundPlaying
+
+        init(assets: AssetGenerating, data: GameData, sound: SoundPlaying) {
+            self.assets = assets
+            self.data = data
+            self.sound = sound
+        }
+
+        func registerDailyStreak() -> DailyStreak {
+            data.registerDailyPlay()
+        }
+
+        var highScoreText: String { "Best: \(data.highScore)" }
+
+        var iapProducts: [IAPProduct] {
+            return [
+                IAPProduct(title: "Remove Ads", price: "$2.99", description: "Fly ad-free forever."),
+                IAPProduct(title: "Starter Pack", price: "$0.99", description: "Nova Pod skin + 200 gems"),
+                IAPProduct(title: "100 Gems", price: "$0.99", description: "Boost your collection."),
+                IAPProduct(title: "550 Gems", price: "$4.99", description: "+10% bonus gems."),
+                IAPProduct(title: "1200 Gems", price: "$9.99", description: "+20% bonus gems.")
+            ]
+        }
+
+        func createButton(title: String, size: CGSize) -> SKSpriteNode {
+            assets.makeButtonNode(text: title, size: size)
+        }
+
+        func playStartSound() {
+            sound.play(.gameStart)
+        }
+    }
+
+    public weak var menuDelegate: MenuSceneDelegate?
+
+    private let viewModel: ViewModel
+    private let assets: AssetGenerating
+    private var startButton: SKSpriteNode?
+    private var streakLabel: SKLabelNode?
+
+    public init(size: CGSize, viewModel: ViewModel, assets: AssetGenerating) {
+        self.viewModel = viewModel
+        self.assets = assets
+        super.init(size: size)
+        scaleMode = .resizeFill
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func didMove(to view: SKView) {
+        anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        backgroundColor = GamePalette.deepNavy
+
+        let background = assets.makeBackground(size: view.bounds.size)
+        addChild(background)
+
+        let title = SKLabelNode(text: "Orbit Flip Frenzy")
+        title.fontName = "Orbitron-Bold"
+        title.fontSize = 42
+        title.fontColor = GamePalette.solarGold
+        title.position = CGPoint(x: 0, y: view.bounds.height * 0.2)
+        title.alpha = 0
+        title.run(SKAction.fadeIn(withDuration: 1.0))
+        addChild(title)
+
+        let subtitle = SKLabelNode(text: "Flip faster, dodge harder, own the orbit.")
+        subtitle.fontName = "SFProRounded-Bold"
+        subtitle.fontSize = 16
+        subtitle.fontColor = GamePalette.cyan
+        subtitle.position = CGPoint(x: 0, y: title.position.y - 60)
+        subtitle.alpha = 0
+        subtitle.run(SKAction.sequence([SKAction.wait(forDuration: 0.3), SKAction.fadeIn(withDuration: 0.8)]))
+        addChild(subtitle)
+
+        let start = viewModel.createButton(title: "Tap to Launch", size: CGSize(width: 240, height: 80))
+        start.position = CGPoint(x: 0, y: -20)
+        start.name = "start"
+        start.alpha = 0
+        start.run(SKAction.sequence([SKAction.wait(forDuration: 0.6), SKAction.fadeIn(withDuration: 0.6)]))
+        addChild(start)
+        startButton = start
+
+        let pulse = SKAction.sequence([
+            SKAction.scale(to: 1.05, duration: 0.8),
+            SKAction.scale(to: 1.0, duration: 0.8)
+        ])
+        start.run(SKAction.repeatForever(pulse))
+
+        let streak = viewModel.registerDailyStreak()
+        let streakNode = SKLabelNode(text: "Daily Streak: \(streak.streakDays) days • Reward +\(Int(streak.reward)) gems")
+        streakNode.fontName = "SFProRounded-Bold"
+        streakNode.fontColor = .white
+        streakNode.fontSize = 18
+        streakNode.position = CGPoint(x: 0, y: -view.bounds.height * 0.2)
+        addChild(streakNode)
+        streakLabel = streakNode
+
+        let bestLabel = SKLabelNode(text: viewModel.highScoreText)
+        bestLabel.fontName = "Orbitron-Bold"
+        bestLabel.fontSize = 18
+        bestLabel.fontColor = GamePalette.solarGold
+        bestLabel.position = CGPoint(x: 0, y: streakNode.position.y - 40)
+        addChild(bestLabel)
+
+        layoutProducts(around: bestLabel.position.y - 60)
+    }
+
+    private func layoutProducts(around y: CGFloat) {
+        let products = viewModel.iapProducts
+        let spacing: CGFloat = 38
+        for (index, product) in products.enumerated() {
+            let label = SKLabelNode(text: "• \(product.title) — \(product.price)")
+            label.fontName = "SFProRounded-Bold"
+            label.fontColor = GamePalette.cyan
+            label.fontSize = 18
+            label.position = CGPoint(x: 0, y: y - CGFloat(index) * spacing)
+            label.name = "product_\(product.title)"
+            label.userData = ["product": product.title]
+            addChild(label)
+
+            let detail = SKLabelNode(text: product.description)
+            detail.fontName = "SFProRounded-Regular"
+            detail.fontColor = UIColor.white.withAlphaComponent(0.7)
+            detail.fontSize = 14
+            detail.position = CGPoint(x: 0, y: label.position.y - 18)
+            detail.name = "product_detail_\(product.title)"
+            detail.userData = ["product": product.title]
+            addChild(detail)
+        }
+    }
+
+    public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let location = touches.first?.location(in: self) else { return }
+        let nodes = nodes(at: location)
+        if let start = startButton, nodes.contains(start) || nodes.contains(where: { $0.name == "label" && $0.parent == start }) {
+            startButton?.setPressed(true)
+        }
+    }
+
+    public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let location = touches.first?.location(in: self) else { return }
+        startButton?.setPressed(false)
+        let nodes = nodes(at: location)
+        if let start = startButton, nodes.contains(start) || nodes.contains(where: { $0.name == "label" && $0.parent == start }) {
+            viewModel.playStartSound()
+            menuDelegate?.menuSceneDidStartGame(self)
+            return
+        }
+        if let label = nodes.compactMap({ $0 as? SKLabelNode }).first,
+           let productTitle = label.userData?["product"] as? String {
+            menuDelegate?.menuScene(self, didSelectProduct: productTitle)
+        }
+    }
+}

--- a/OrbitFlipFrenzy/PhysicsCategories.swift
+++ b/OrbitFlipFrenzy/PhysicsCategories.swift
@@ -1,0 +1,10 @@
+import Foundation
+import SpriteKit
+
+public struct PhysicsCategory {
+    public static let none: UInt32 = 0
+    public static let player: UInt32 = 0x1 << 0
+    public static let obstacle: UInt32 = 0x1 << 1
+    public static let powerUp: UInt32 = 0x1 << 2
+    public static let ghost: UInt32 = 0x1 << 3
+}

--- a/OrbitFlipFrenzy/PowerupSystem.swift
+++ b/OrbitFlipFrenzy/PowerupSystem.swift
@@ -1,0 +1,85 @@
+import Foundation
+import SpriteKit
+
+public enum PowerUp: CustomStringConvertible, Codable {
+    case shield(duration: TimeInterval)
+    case slowMo(factor: CGFloat, duration: TimeInterval)
+    case magnet(strength: CGFloat, duration: TimeInterval)
+
+    public var description: String {
+        switch self {
+        case let .shield(duration):
+            return "shield(\(duration))"
+        case let .slowMo(factor, duration):
+            return "slowMo(\(factor), \(duration))"
+        case let .magnet(strength, duration):
+            return "magnet(\(strength), \(duration))"
+        }
+    }
+
+    public var type: PowerUpType {
+        switch self {
+        case .shield:
+            return .shield
+        case .slowMo:
+            return .slowMo
+        case .magnet:
+            return .magnet
+        }
+    }
+}
+
+public enum PowerUpType: String, Codable {
+    case shield
+    case slowMo
+    case magnet
+}
+
+private struct ActivePowerup {
+    let type: PowerUp
+    let expiresAt: TimeInterval
+}
+
+public protocol PowerupManaging {
+    func activate(_ powerUp: PowerUp, currentTime: TimeInterval)
+    func isActive(_ type: PowerUpType, currentTime: TimeInterval) -> Bool
+    func update(currentTime: TimeInterval)
+    var activeTypes: [PowerUpType] { get }
+}
+
+public final class PowerupManager: PowerupManaging {
+    private var active: [ActivePowerup] = []
+
+    public init() {}
+
+    public func activate(_ powerUp: PowerUp, currentTime: TimeInterval) {
+        let duration: TimeInterval
+        switch powerUp {
+        case let .shield(d):
+            duration = d
+        case let .slowMo(_, d):
+            duration = d
+        case let .magnet(_, d):
+            duration = d
+        }
+        let activePowerup = ActivePowerup(type: powerUp, expiresAt: currentTime + duration)
+        active.removeAll { $0.type.type == powerUp.type }
+        active.append(activePowerup)
+    }
+
+    public func isActive(_ type: PowerUpType, currentTime: TimeInterval) -> Bool {
+        active.contains { $0.type.type == type && currentTime < $0.expiresAt }
+    }
+
+    public func update(currentTime: TimeInterval) {
+        active.removeAll { currentTime >= $0.expiresAt }
+    }
+
+    public var activeTypes: [PowerUpType] {
+        active.map { $0.type.type }
+    }
+
+    public func currentPowerUp(of type: PowerUpType) -> PowerUp? {
+        active.first { $0.type.type == type }?.type
+    }
+}

--- a/OrbitFlipFrenzy/SoundEngine.swift
+++ b/OrbitFlipFrenzy/SoundEngine.swift
@@ -1,0 +1,99 @@
+import Foundation
+import AVFoundation
+
+public enum SoundEvent {
+    case gameStart
+    case playerFlip
+    case nearMiss
+    case collision
+    case milestone
+    case powerupCollect
+}
+
+public protocol SoundPlaying {
+    func play(_ event: SoundEvent)
+}
+
+public final class SoundEngine: SoundPlaying {
+    private let engine = AVAudioEngine()
+    private let player = AVAudioPlayerNode()
+    private let mixer = AVAudioMixerNode()
+    private let queue = DispatchQueue(label: "SoundEngineQueue")
+
+    public init() {
+        engine.attach(player)
+        engine.attach(mixer)
+        engine.connect(player, to: mixer, format: nil)
+        engine.connect(mixer, to: engine.mainMixerNode, format: nil)
+        mixer.volume = 0.7
+        try? engine.start()
+    }
+
+    public func play(_ event: SoundEvent) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            let (frequencies, durations) = self.configuration(for: event)
+            let buffer = self.generateBuffer(frequencies: frequencies, durations: durations)
+            self.player.stop()
+            self.player.scheduleBuffer(buffer, at: nil, options: [])
+            if !self.player.isPlaying {
+                self.player.play()
+            }
+        }
+    }
+
+    private func configuration(for event: SoundEvent) -> ([Double], [Double]) {
+        switch event {
+        case .gameStart:
+            return (stride(from: 130.81, through: 392.0, by: 30.0).map { $0 }, Array(repeating: 0.05, count: 9))
+        case .playerFlip:
+            return ([440.0], [0.1])
+        case .nearMiss:
+            return ([2000.0, 2100.0, 2200.0], [0.05, 0.05, 0.05])
+        case .collision:
+            return ([80.0, 60.0], [0.1, 0.1])
+        case .milestone:
+            return ([261.63, 329.63, 392.0, 523.25], [0.1, 0.1, 0.1, 0.1])
+        case .powerupCollect:
+            return ([261.63, 329.63, 392.0], [0.1, 0.1, 0.1])
+        }
+    }
+
+    private func generateBuffer(frequencies: [Double], durations: [Double]) -> AVAudioPCMBuffer {
+        let sampleRate = 44_100.0
+        let totalDuration = zip(frequencies, durations).reduce(0.0) { partial, pair in
+            let (_, duration) = pair
+            return partial + duration
+        }
+        let totalFrames = max(AVAudioFrameCount(1), AVAudioFrameCount(totalDuration * sampleRate))
+        let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: totalFrames)!
+        buffer.frameLength = totalFrames
+        var frameIndex: AVAudioFrameCount = 0
+        for (frequency, duration) in zip(frequencies, durations) {
+            let frames = AVAudioFrameCount(duration * sampleRate)
+            let envelopeFrames = max(AVAudioFrameCount(1), frames)
+            for i in 0..<frames {
+                let phase = Double(i) / sampleRate * frequency * 2.0 * Double.pi
+                let value = sin(phase)
+                let envelope = self.envelope(for: Int(i), total: Int(envelopeFrames))
+                buffer.floatChannelData?.pointee[Int(frameIndex + i)] = Float(value * envelope)
+            }
+            frameIndex += frames
+        }
+        return buffer
+    }
+
+    private func envelope(for index: Int, total: Int) -> Double {
+        guard total > 0 else { return 1.0 }
+        let attack = Int(Double(total) * 0.1)
+        let release = Int(Double(total) * 0.2)
+        if index < attack {
+            return Double(index) / Double(max(attack, 1))
+        }
+        if index > total - release {
+            return max(Double(total - index) / Double(max(release, 1)), 0.0)
+        }
+        return 1.0
+    }
+}


### PR DESCRIPTION
## Summary
- implement the Orbit Flip Frenzy SpriteKit gameplay loop with near-miss multipliers, progressive rings, power-ups, and replay capture
- add menu, game-over, and controller layers with daily streaks, rewarded ad simulation, shareable challenges, and dependency-injected services
- generate all assets, sounds, haptics, analytics, and configuration programmatically for an App Store-ready SwiftUI wrapper

## Testing
- not run (SpriteKit project)


------
https://chatgpt.com/codex/tasks/task_e_68d118dfe5208328a1f79a5c32dc4d45