### PR TITLE
Enhance Orbital Flip Frenzy HUD and power-up feedback

### DIFF
--- a/OrbitFlipFrenzy/GameScene.swift
+++ b/OrbitFlipFrenzy/GameScene.swift
@@ -62,6 +62,21 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
 
         var elapsedTime: TimeInterval { Date().timeIntervalSince(startDate) }
 
+        var streakMultiplier: CGFloat {
+            if data.dailyStreak.isMultiplierActive {
+                return CGFloat(data.dailyStreak.multiplierBonus)
+            }
+            return 1.0
+        }
+
+        var isStreakMultiplierActive: Bool { data.dailyStreak.isMultiplierActive }
+
+        var streakDays: Int { data.dailyStreak.streakDays }
+
+        func totalMultiplier() -> CGFloat {
+            currentMultiplier * streakMultiplier
+        }
+
         func reset() {
             score = 0
             currentMultiplier = 1.0
@@ -81,7 +96,7 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
         @discardableResult
         func handleSafePass() -> Int {
             scoreActions += 1
-            let points = Int(GameConstants.scorePerAction * currentMultiplier)
+            let points = Int(GameConstants.scorePerAction * totalMultiplier())
             score += points
             currentMultiplier = max(1.0, currentMultiplier * GameConstants.multiplierDecayFactor)
             if scoreActions % 20 == 0 {
@@ -226,7 +241,7 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
     private let assets: AssetGenerating
     private let sound: SoundPlaying
     private let haptics: HapticProviding
-    private let powerups: PowerupManager
+    private let powerups: PowerupManaging
     private let obstaclePool: ObstaclePool
     private let replayRecorder = ReplayRecorder()
 
@@ -235,6 +250,15 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
     private var playerNode: SKShapeNode!
     private var ghostNode: SKShapeNode?
     private var socialProofLabel: SKLabelNode?
+    private var scoreLabel: SKLabelNode?
+    private var multiplierLabel: SKLabelNode?
+    private var levelLabel: SKLabelNode?
+    private var powerupLabel: SKLabelNode?
+    private var streakLabel: SKLabelNode?
+    private var streakBadge: SKShapeNode?
+    private var eventBanner: SKLabelNode?
+    private var shieldAura: SKShapeNode?
+    private var inversionOverlay: SKSpriteNode?
 
     private var lastUpdate: TimeInterval = 0
     private var spawnTimer: TimeInterval = 0
@@ -255,6 +279,15 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
 
     private var powerUpNodes: [SKShapeNode] = []
 
+    private var activePowerupTypes: Set<PowerUpType> = []
+    private var lastKnownLevel: Int = 1
+    private var lastStreakActive: Bool = false
+    private var lastStreakMultiplier: CGFloat = 1.0
+
+    private let streakPulseActionKey = "streakPulse"
+    private lazy var nearMissTexture: SKTexture? = assets.makeParticleTexture(radius: 6, color: GamePalette.solarGold)
+    private lazy var scoreBurstTexture: SKTexture? = assets.makeParticleTexture(radius: 4, color: GamePalette.neonMagenta)
+
     private var currentTimeSnapshot: TimeInterval = 0
 
     // MARK: - Initialization
@@ -264,7 +297,7 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
                 assets: AssetGenerating,
                 sound: SoundPlaying,
                 haptics: HapticProviding,
-                powerups: PowerupManager) {
+                powerups: PowerupManaging) {
         self.viewModel = viewModel
         self.assets = assets
         self.sound = sound
@@ -295,10 +328,22 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
         configurePlayer()
         configureGhost()
         configureSocialProof()
+        configureHUD()
 
         viewModel.reset()
+        lastKnownLevel = viewModel.level
+        lastStreakActive = viewModel.isStreakMultiplierActive
+        lastStreakMultiplier = viewModel.streakMultiplier
+        activePowerupTypes = Set(powerups.activeTypes)
+        updateHUD()
+        updatePowerupHUDIfNeeded()
         viewModel.registerStart()
         specialEventsTriggered.removeAll()
+    }
+
+    public override func didChangeSize(_ oldSize: CGSize) {
+        super.didChangeSize(oldSize)
+        layoutHUD()
     }
 
     private func configureRings() {
@@ -359,6 +404,259 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
         label.run(SKAction.repeatForever(sequence))
     }
 
+    private func configureHUD() {
+        scoreLabel?.removeFromParent()
+        multiplierLabel?.removeFromParent()
+        levelLabel?.removeFromParent()
+        powerupLabel?.removeFromParent()
+        streakBadge?.removeFromParent()
+        eventBanner?.removeFromParent()
+
+        let score = SKLabelNode(fontNamed: "Orbitron-Bold")
+        score.fontSize = 28
+        score.fontColor = .white
+        score.text = "Score: 0"
+        score.verticalAlignmentMode = .center
+        score.horizontalAlignmentMode = .center
+        score.zPosition = 50
+        addChild(score)
+        scoreLabel = score
+
+        let multiplier = SKLabelNode(fontNamed: "SFProRounded-Bold")
+        multiplier.fontSize = 18
+        multiplier.fontColor = GamePalette.cyan
+        multiplier.text = "Multiplier: x1.0"
+        multiplier.verticalAlignmentMode = .center
+        multiplier.horizontalAlignmentMode = .center
+        multiplier.zPosition = 50
+        addChild(multiplier)
+        multiplierLabel = multiplier
+
+        let level = SKLabelNode(fontNamed: "SFProRounded-Bold")
+        level.fontSize = 18
+        level.fontColor = GamePalette.solarGold
+        level.text = "Level 1"
+        level.verticalAlignmentMode = .center
+        level.horizontalAlignmentMode = .center
+        level.zPosition = 50
+        addChild(level)
+        levelLabel = level
+
+        let power = SKLabelNode(fontNamed: "SFProRounded-Regular")
+        power.fontSize = 14
+        power.fontColor = UIColor.white.withAlphaComponent(0.8)
+        power.text = "Power-ups: None"
+        power.verticalAlignmentMode = .center
+        power.horizontalAlignmentMode = .center
+        power.zPosition = 50
+        addChild(power)
+        powerupLabel = power
+
+        let badge = SKShapeNode(rectOf: CGSize(width: 200, height: 40), cornerRadius: 20)
+        badge.fillColor = GamePalette.solarGold.withAlphaComponent(0.15)
+        badge.strokeColor = GamePalette.solarGold
+        badge.lineWidth = 2
+        badge.alpha = 0.4
+        badge.zPosition = 50
+        addChild(badge)
+        streakBadge = badge
+
+        let streakText = SKLabelNode(fontNamed: "SFProRounded-Bold")
+        streakText.fontSize = 16
+        streakText.fontColor = GamePalette.solarGold
+        streakText.verticalAlignmentMode = .center
+        streakText.horizontalAlignmentMode = .center
+        streakText.text = "Streak Ready"
+        streakText.zPosition = 51
+        badge.addChild(streakText)
+        streakLabel = streakText
+
+        let banner = SKLabelNode(fontNamed: "Orbitron-Bold")
+        banner.fontSize = 20
+        banner.fontColor = GamePalette.solarGold
+        banner.verticalAlignmentMode = .center
+        banner.horizontalAlignmentMode = .center
+        banner.alpha = 0
+        banner.zPosition = 60
+        addChild(banner)
+        eventBanner = banner
+
+        layoutHUD()
+    }
+
+    private func layoutHUD() {
+        let topY = size.height * 0.42
+        levelLabel?.position = CGPoint(x: -size.width * 0.35, y: topY)
+        scoreLabel?.position = CGPoint(x: 0, y: topY)
+        multiplierLabel?.position = CGPoint(x: 0, y: topY - 36)
+        if let badge = streakBadge {
+            badge.position = CGPoint(x: size.width * 0.35, y: topY)
+        }
+        powerupLabel?.position = CGPoint(x: 0, y: -size.height * 0.45)
+        eventBanner?.position = CGPoint(x: 0, y: size.height * 0.28)
+        inversionOverlay?.position = .zero
+        inversionOverlay?.size = size
+    }
+
+    private func updateHUD() {
+        scoreLabel?.text = "Score: \(viewModel.score)"
+        let totalMultiplier = Double(viewModel.totalMultiplier())
+        multiplierLabel?.text = String(format: "Multiplier: x%.1f", totalMultiplier)
+        levelLabel?.text = "Level \(viewModel.level)"
+        updateStreakBadge()
+    }
+
+    private func updateStreakBadge() {
+        guard let badge = streakBadge, let label = streakLabel else { return }
+        if viewModel.isStreakMultiplierActive {
+            let multiplier = Double(viewModel.streakMultiplier)
+            label.text = String(format: "Streak x%.1f • %dd", multiplier, viewModel.streakDays)
+            badge.alpha = 1.0
+            if badge.action(forKey: streakPulseActionKey) == nil {
+                let pulse = SKAction.sequence([
+                    SKAction.scale(to: 1.05, duration: 0.45),
+                    SKAction.scale(to: 1.0, duration: 0.45)
+                ])
+                badge.run(SKAction.repeatForever(pulse), withKey: streakPulseActionKey)
+            }
+        } else {
+            label.text = "Build your streak"
+            badge.alpha = 0.4
+            badge.removeAction(forKey: streakPulseActionKey)
+            badge.setScale(1.0)
+        }
+    }
+
+    private func updatePowerupHUDIfNeeded() {
+        let current = Set(powerups.activeTypes)
+        guard current != activePowerupTypes else { return }
+        activePowerupTypes = current
+        if current.isEmpty {
+            powerupLabel?.text = "Power-ups: None"
+            powerupLabel?.fontColor = UIColor.white.withAlphaComponent(0.8)
+        } else {
+            let names = current.map { $0.displayName }.sorted()
+            powerupLabel?.text = "Power-ups: " + names.joined(separator: ", ")
+            powerupLabel?.fontColor = GamePalette.cyan
+        }
+    }
+
+    private func updateShieldAura() {
+        let shieldActive = powerups.isActive(.shield, currentTime: currentTimeSnapshot)
+        if shieldActive {
+            guard shieldAura == nil else { return }
+            let radius = max(playerNode.frame.width / 2 + 14, 24)
+            let aura = SKShapeNode(circleOfRadius: radius)
+            aura.strokeColor = GamePalette.cyan
+            aura.fillColor = GamePalette.cyan.withAlphaComponent(0.15)
+            aura.lineWidth = 3
+            aura.glowWidth = 8
+            aura.alpha = 0
+            aura.zPosition = -1
+            let pulse = SKAction.sequence([
+                SKAction.scale(to: 1.05, duration: 0.4),
+                SKAction.scale(to: 1.0, duration: 0.4)
+            ])
+            aura.run(SKAction.repeatForever(pulse))
+            aura.run(SKAction.fadeIn(withDuration: 0.2))
+            playerNode.addChild(aura)
+            shieldAura = aura
+        } else if let aura = shieldAura {
+            aura.run(SKAction.sequence([
+                SKAction.fadeOut(withDuration: 0.2),
+                SKAction.removeFromParent()
+            ]))
+            shieldAura = nil
+        }
+    }
+
+    private func emitNearMiss(at position: CGPoint) {
+        guard let texture = nearMissTexture else { return }
+        let emitter = SKEmitterNode()
+        emitter.particleTexture = texture
+        emitter.numParticlesToEmit = 28
+        emitter.particleLifetime = 0.6
+        emitter.particleBirthRate = 200
+        emitter.particleAlpha = 0.9
+        emitter.particleAlphaSpeed = -1.2
+        emitter.particleSpeed = 120
+        emitter.particleSpeedRange = 40
+        emitter.particleScale = 0.35
+        emitter.particleScaleSpeed = -0.2
+        emitter.particleColorBlendFactor = 1
+        emitter.particleColor = GamePalette.solarGold
+        emitter.position = position
+        emitter.zPosition = 80
+        addChild(emitter)
+        emitter.run(SKAction.sequence([
+            SKAction.wait(forDuration: 0.7),
+            SKAction.removeFromParent()
+        ]))
+    }
+
+    private func showScorePopup(for points: Int, at position: CGPoint) {
+        let label = SKLabelNode(fontNamed: "SFProRounded-Bold")
+        label.fontSize = 16
+        label.fontColor = GamePalette.solarGold
+        label.text = "+\(points)"
+        label.position = position
+        label.zPosition = 80
+        label.alpha = 0
+        addChild(label)
+        let rise = SKAction.moveBy(x: 0, y: 32, duration: 0.6)
+        let fadeIn = SKAction.fadeAlpha(to: 1.0, duration: 0.1)
+        let fadeOut = SKAction.fadeOut(withDuration: 0.5)
+        label.run(SKAction.sequence([
+            fadeIn,
+            SKAction.group([rise, fadeOut]),
+            SKAction.removeFromParent()
+        ]))
+
+        if let texture = scoreBurstTexture {
+            let emitter = SKEmitterNode()
+            emitter.particleTexture = texture
+            emitter.numParticlesToEmit = 18
+            emitter.particleLifetime = 0.4
+            emitter.particleBirthRate = 150
+            emitter.particleAlpha = 0.8
+            emitter.particleAlphaSpeed = -1.5
+            emitter.particleSpeed = 90
+            emitter.particleScale = 0.3
+            emitter.particleScaleSpeed = -0.2
+            emitter.particleColorBlendFactor = 1
+            emitter.particleColor = GamePalette.neonMagenta
+            emitter.position = position
+            emitter.zPosition = 75
+            addChild(emitter)
+            emitter.run(SKAction.sequence([
+                SKAction.wait(forDuration: 0.5),
+                SKAction.removeFromParent()
+            ]))
+        }
+    }
+
+    private func showEventBanner(_ text: String) {
+        guard let banner = eventBanner else { return }
+        banner.text = text
+        banner.removeAllActions()
+        banner.alpha = 0
+        banner.run(SKAction.sequence([
+            SKAction.fadeIn(withDuration: 0.2),
+            SKAction.wait(forDuration: 1.8),
+            SKAction.fadeOut(withDuration: 0.3)
+        ]))
+    }
+
+    private func refreshStreakIfNeeded() {
+        let active = viewModel.isStreakMultiplierActive
+        let multiplier = viewModel.streakMultiplier
+        if active != lastStreakActive || abs(multiplier - lastStreakMultiplier) > 0.001 {
+            lastStreakActive = active
+            lastStreakMultiplier = multiplier
+            updateHUD()
+        }
+    }
+
     // MARK: - Touch Handling
 
     public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -384,6 +682,12 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
         } else {
             performFlip(doubleJump: false)
         }
+    }
+
+    public override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard !isGameOver else { return }
+        touchBeganTime = nil
+        doubleFlipArmed = false
     }
 
     private func performFlip(doubleJump: Bool) {
@@ -448,14 +752,17 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
         updateObstacles(currentTime: currentTime)
         updatePowerups(currentTime: currentTime)
         updateGhostFollowing()
-        applyMagnetIfNeeded()
+        applyMagnetIfNeeded(delta: delta)
+        updateShieldAura()
+        updatePowerupHUDIfNeeded()
+        refreshStreakIfNeeded()
         handleSpecialEvents()
     }
 
     private func updateRings(delta: TimeInterval) {
         var speed = viewModel.currentSpeed()
-        if powerups.isActive(.slowMo, currentTime: currentTimeSnapshot) {
-            speed *= GameConstants.powerupSlowFactor
+        if let slow = powerups.currentPowerUp(of: .slowMo)?.slowFactor {
+            speed *= slow
         }
         for (index, container) in ringContainers.enumerated() {
             guard index < activeRingCount else {
@@ -472,8 +779,8 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
     private func updateSpawn(delta: TimeInterval, currentTime: TimeInterval) {
         spawnTimer += delta
         var spawnRate = meteorShowerEnds > currentTime ? max(0.2, viewModel.currentSpawnRate() * 0.6) : viewModel.currentSpawnRate()
-        if powerups.isActive(.slowMo, currentTime: currentTimeSnapshot) {
-            spawnRate *= 1.5
+        if let slow = powerups.currentPowerUp(of: .slowMo)?.slowFactor, slow > 0 {
+            spawnRate /= Double(slow)
         }
         while spawnTimer >= spawnRate {
             spawnTimer -= spawnRate
@@ -556,8 +863,15 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
     }
 
     private func obstacleCleared(_ obstacle: SKShapeNode) {
-        _ = viewModel.handleSafePass()
+        let points = viewModel.handleSafePass()
         obstaclePool.recycle(obstacle)
+        updateHUD()
+        let playerPosition = playerNode.parent?.convert(playerNode.position, to: self) ?? .zero
+        showScorePopup(for: points, at: playerPosition)
+        if viewModel.level != lastKnownLevel {
+            lastKnownLevel = viewModel.level
+            showEventBanner("Level \(viewModel.level) unlocked")
+        }
     }
 
     private func handleNearMissCheck(for obstacle: SKShapeNode) {
@@ -569,6 +883,8 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
             obstacle.userData?["near"] = true
             viewModel.handleNearMiss()
             sound.play(.nearMiss)
+            updateHUD()
+            emitNearMiss(at: playerPosition)
         }
     }
 
@@ -603,6 +919,8 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
         }
         powerups.activate(powerUp, currentTime: currentTime)
         viewModel.registerPowerup(powerUp)
+        updatePowerupHUDIfNeeded()
+        updateShieldAura()
     }
 
     private func determinePowerUpType(from node: SKShapeNode) -> PowerUpType? {
@@ -641,24 +959,29 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
         ghost.run(follow)
     }
 
-    private func applyMagnetIfNeeded() {
-        guard powerups.isActive(.magnet, currentTime: currentTimeSnapshot) else { return }
+    private func applyMagnetIfNeeded(delta: TimeInterval) {
+        guard let magnet = powerups.currentPowerUp(of: .magnet),
+              let strength = magnet.magnetStrength,
+              powerups.isActive(.magnet, currentTime: currentTimeSnapshot) else { return }
         let obstacles = obstaclePool.allActive()
         guard !obstacles.isEmpty, let parent = playerNode.parent else { return }
         let playerPosition = parent.convert(playerNode.position, to: self)
-        let nearest = obstacles.min(by: { lhs, rhs in
+        guard let obstacle = obstacles.min(by: { lhs, rhs in
             let left = lhs.parent?.convert(lhs.position, to: self) ?? .zero
             let right = rhs.parent?.convert(rhs.position, to: self) ?? .zero
             return playerPosition.distance(to: left) < playerPosition.distance(to: right)
-        })
-        guard let obstacle = nearest else { return }
+        }) else { return }
         let obstaclePosition = obstacle.parent?.convert(obstacle.position, to: self) ?? .zero
         let safeAngle = atan2(obstaclePosition.y, obstaclePosition.x) + (.pi / 2)
         let currentAngle = atan2(playerPosition.y, playerPosition.x)
-        let delta = shortestAngleBetween(currentAngle, safeAngle)
-        let adjustedAngle = currentAngle + delta * 0.08
+        let difference = shortestAngleBetween(currentAngle, safeAngle)
+        guard abs(difference) > 0.001 else { return }
+        let clampStrength = min(0.35, max(0.1, strength / 200.0))
+        let adjustment = difference * clampStrength * CGFloat(delta * 60.0)
         let radius = playerPosition.length()
-        let newPosition = CGPoint(x: cos(adjustedAngle) * radius, y: sin(adjustedAngle) * radius)
+        guard radius > GameConstants.magnetSafeZoneRadius else { return }
+        let newAngle = currentAngle + adjustment
+        let newPosition = CGPoint(x: cos(newAngle) * radius, y: sin(newAngle) * radius)
         playerNode.position = convert(newPosition, to: parent)
     }
 
@@ -680,15 +1003,35 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
 
     private func triggerColorInversion() {
         inversionEnds = currentTimeSnapshot + GameConstants.inversionDuration
-        let invertAction = SKAction.customAction(withDuration: GameConstants.inversionDuration) { [weak self] _, elapsed in
-            guard let self else { return }
-            let progress = elapsed / CGFloat(GameConstants.inversionDuration)
-            self.backgroundNode?.color = UIColor.white.withAlphaComponent(progress)
-            self.backgroundNode?.colorBlendFactor = progress
+        let overlay: SKSpriteNode
+        if let existing = inversionOverlay {
+            overlay = existing
+        } else {
+            overlay = SKSpriteNode(color: .white, size: size)
+            overlay.blendMode = .difference
+            overlay.zPosition = 100
+            overlay.alpha = 0
+            addChild(overlay)
+            inversionOverlay = overlay
         }
-        backgroundNode?.run(SKAction.sequence([invertAction, SKAction.run { [weak self] in
-            self?.backgroundNode?.colorBlendFactor = 0
-        }]))
+        overlay.removeAllActions()
+        overlay.position = .zero
+        overlay.size = size
+        let duration = GameConstants.inversionDuration
+        overlay.run(SKAction.sequence([
+            SKAction.fadeAlpha(to: 1.0, duration: 0.3),
+            SKAction.wait(forDuration: max(0, duration - 0.6)),
+            SKAction.fadeAlpha(to: 0.0, duration: 0.3),
+            SKAction.run { [weak self] in
+                guard let self else { return }
+                if self.currentTimeSnapshot >= self.inversionEnds {
+                    self.inversionOverlay?.removeFromParent()
+                    self.inversionOverlay = nil
+                }
+                self.inversionEnds = 0
+            }
+        ]))
+        showEventBanner("Color inversion!")
     }
 
     private func triggerMeteorShower() {
@@ -697,10 +1040,12 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
             let rainbow = UIColor(hue: CGFloat.random(in: 0...1), saturation: 0.9, brightness: 1.0, alpha: 1.0)
             spawnObstacle(at: currentTimeSnapshot, colorOverride: rainbow)
         }
+        showEventBanner("Rainbow meteor shower!")
     }
 
     private func triggerGravityReversal() {
         gravityEnds = currentTimeSnapshot + GameConstants.gravityReversalDuration
+        showEventBanner("Gravity reversed!")
     }
 
     // MARK: - Contact Handling
@@ -734,6 +1079,15 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
         isGameOver = true
         viewModel.registerCollision()
         viewModel.finalizeScore()
+        shieldAura?.removeAllActions()
+        shieldAura?.removeFromParent()
+        shieldAura = nil
+        inversionOverlay?.removeAllActions()
+        inversionOverlay?.removeFromParent()
+        inversionOverlay = nil
+        inversionEnds = 0
+        eventBanner?.removeAllActions()
+        eventBanner?.alpha = 0
         let result = GameResult(score: viewModel.score,
                                 duration: viewModel.elapsedTime,
                                 nearMisses: viewModel.nearMisses,
@@ -750,6 +1104,9 @@ public final class GameScene: SKScene, SKPhysicsContactDelegate {
         if withShield {
             powerups.activate(.shield(duration: GameConstants.powerupShieldDuration), currentTime: currentTimeSnapshot)
         }
+        updateShieldAura()
+        updatePowerupHUDIfNeeded()
+        updateHUD()
         spawnTimer = 0
         specialEventsTriggered.removeAll()
         obstaclePool.allActive().forEach { obstaclePool.recycle($0) }

--- a/OrbitFlipFrenzy/PowerupSystem.swift
+++ b/OrbitFlipFrenzy/PowerupSystem.swift
@@ -43,6 +43,7 @@ private struct ActivePowerup {
 public protocol PowerupManaging {
     func activate(_ powerUp: PowerUp, currentTime: TimeInterval)
     func isActive(_ type: PowerUpType, currentTime: TimeInterval) -> Bool
+    func currentPowerUp(of type: PowerUpType) -> PowerUp?
     func update(currentTime: TimeInterval)
     var activeTypes: [PowerUpType] { get }
 }
@@ -81,5 +82,30 @@ public final class PowerupManager: PowerupManaging {
 
     public func currentPowerUp(of type: PowerUpType) -> PowerUp? {
         active.first { $0.type.type == type }?.type
+    }
+}
+
+public extension PowerUpType {
+    var displayName: String {
+        switch self {
+        case .shield:
+            return "Shield"
+        case .slowMo:
+            return "Slow-Mo"
+        case .magnet:
+            return "Magnet"
+        }
+    }
+}
+
+public extension PowerUp {
+    var slowFactor: CGFloat? {
+        if case let .slowMo(factor, _) = self { return factor }
+        return nil
+    }
+
+    var magnetStrength: CGFloat? {
+        if case let .magnet(strength, _) = self { return strength }
+        return nil
     }
 }

--- a/OrbitFlipFrenzy/SoundEngine.swift
+++ b/OrbitFlipFrenzy/SoundEngine.swift
@@ -45,7 +45,7 @@ public final class SoundEngine: SoundPlaying {
     private func configuration(for event: SoundEvent) -> ([Double], [Double]) {
         switch event {
         case .gameStart:
-            return (stride(from: 130.81, through: 392.0, by: 30.0).map { $0 }, Array(repeating: 0.05, count: 9))
+            return ([130.81, 174.61, 220.0, 261.63, 329.63, 392.0], Array(repeating: 0.05, count: 6))
         case .playerFlip:
             return ([440.0], [0.1])
         case .nearMiss:


### PR DESCRIPTION
## Summary
- wire daily streak multipliers into scoring and adjust slow-mo/magnet handling while improving obstacle-clear and near-miss feedback
- add an in-game HUD with score, multiplier, streak, power-up status, event banners, shield aura, and particle-driven highlights for special moments
- expose power-up metadata for UI use and tighten the synthesized game-start sweep to a concise C3→G4 ramp

## Testing
- Not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68d1d6b005a0832889ce171dc4fe2dd3