### PR TITLE
Improve power-up UI feedback and special event effects

### DIFF
--- a/OrbitFlipFrenzy/PowerupSystem.swift
+++ b/OrbitFlipFrenzy/PowerupSystem.swift
@@ -45,6 +45,7 @@ public protocol PowerupManaging {
     func isActive(_ type: PowerUpType, currentTime: TimeInterval) -> Bool
     func currentPowerUp(of type: PowerUpType) -> PowerUp?
     func update(currentTime: TimeInterval)
+    func timeRemaining(for type: PowerUpType, currentTime: TimeInterval) -> TimeInterval?
     var activeTypes: [PowerUpType] { get }
 }
 
@@ -74,6 +75,11 @@ public final class PowerupManager: PowerupManaging {
 
     public func update(currentTime: TimeInterval) {
         active.removeAll { currentTime >= $0.expiresAt }
+    }
+
+    public func timeRemaining(for type: PowerUpType, currentTime: TimeInterval) -> TimeInterval? {
+        guard let entry = active.first(where: { $0.type.type == type }) else { return nil }
+        return max(0, entry.expiresAt - currentTime)
     }
 
     public var activeTypes: [PowerUpType] {


### PR DESCRIPTION
## Summary
- show active power-up names with countdown timers and low-time highlighting in the HUD
- expose power-up time remaining from the manager and clean up meteor state between revives
- add celebratory feedback and a rainbow meteor particle storm during score-based special events

## Testing
- not run (iOS SpriteKit project; no automated tests available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d23c730e54832882cff293fdee68db