### PR TITLE
Add in-app legal documents

### DIFF
--- a/OrbitFlipFrenzy/GameViewController.swift
+++ b/OrbitFlipFrenzy/GameViewController.swift
@@ -95,6 +95,10 @@ extension GameViewController: MenuSceneDelegate {
     func menuSceneDidRequestRestore(_ scene: MenuScene) {
         container.restorePurchases(from: self)
     }
+
+    func menuScene(_ scene: MenuScene, didRequestLegal document: LegalDocument) {
+        container.presentLegal(document: document, from: self)
+    }
 }
 
 extension GameViewController: GameSceneDelegate {
@@ -204,6 +208,15 @@ private final class DependencyContainer {
 
     func restorePurchases(from controller: UIViewController) {
         purchases.presentRestorePurchases(from: controller)
+    }
+
+    func presentLegal(document: LegalDocument, from controller: UIViewController) {
+        let legal = LegalViewController(document: document)
+        let navigation = UINavigationController(rootViewController: legal)
+        navigation.modalPresentationStyle = .formSheet
+        navigation.navigationBar.tintColor = GamePalette.cyan
+        navigation.navigationBar.prefersLargeTitles = false
+        controller.present(navigation, animated: true)
     }
 }
 

--- a/OrbitFlipFrenzy/LegalDocument.swift
+++ b/OrbitFlipFrenzy/LegalDocument.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+public struct LegalSection {
+    public let title: String
+    public let body: String
+}
+
+public enum LegalDocument: CaseIterable {
+    case privacyPolicy
+    case termsOfUse
+
+    public var buttonTitle: String {
+        switch self {
+        case .privacyPolicy:
+            return "Privacy"
+        case .termsOfUse:
+            return "Terms"
+        }
+    }
+
+    public var title: String {
+        switch self {
+        case .privacyPolicy:
+            return "Privacy Policy"
+        case .termsOfUse:
+            return "Terms of Use"
+        }
+    }
+
+    public var subtitle: String {
+        "Last updated: April 15, 2024"
+    }
+
+    public var introduction: String {
+        switch self {
+        case .privacyPolicy:
+            return "Orbit Flip Frenzy respects your privacy. This notice explains what information we collect, how we use it, and the choices you have."
+        case .termsOfUse:
+            return "Welcome to Orbit Flip Frenzy! These terms govern your use of the game, in-app purchases, and social features."
+        }
+    }
+
+    public var sections: [LegalSection] {
+        switch self {
+        case .privacyPolicy:
+            return [
+                LegalSection(title: "1. Information We Collect", body: "We store gameplay metrics such as score, level progress, near-miss counts, and purchase history so you can track achievements and recover entitlements. We do not collect personal contact details unless you share them with support."),
+                LegalSection(title: "2. How We Use Data", body: "Gameplay analytics help balance difficulty, measure the effectiveness of power-ups, and surface daily streak rewards. Purchase logs are required to restore non-consumable items. Aggregated telemetry may be used to improve future updates."),
+                LegalSection(title: "3. Data Sharing", body: "We do not sell your data. Limited telemetry may be shared with service providers (such as analytics or payment partners) solely to operate the game. All partners must adhere to contractual confidentiality obligations."),
+                LegalSection(title: "4. Device Permissions", body: "If you grant permission, the app may access haptics, local photo storage (for replay sharing), and network connectivity. Revoking permissions can limit certain features but will not prevent core gameplay."),
+                LegalSection(title: "5. Retention & Security", body: "Scores and purchase receipts are retained while your account remains active. We use platform security features, encrypted storage, and regular audits to protect your information."),
+                LegalSection(title: "6. Your Choices", body: "You can reset local data from the in-game settings, disable analytics in iOS privacy controls, or delete the app to remove stored information. Contact support@orbitflipfrenzy.com to request data export or deletion."),
+                LegalSection(title: "7. Children's Privacy", body: "The game targets players 13+. If we learn that we have collected data from a younger child without guardian consent, we will delete it promptly."),
+                LegalSection(title: "8. Contact", body: "Reach us at support@orbitflipfrenzy.com or Orbit Flip Frenzy Privacy, 123 Neon Way, San Francisco, CA 94107 USA.")
+            ]
+        case .termsOfUse:
+            return [
+                LegalSection(title: "1. Acceptance", body: "By installing or playing Orbit Flip Frenzy you agree to these terms and to follow applicable laws. If you disagree, uninstall the app."),
+                LegalSection(title: "2. License", body: "We grant you a personal, non-transferable license to play the game for entertainment. Reverse engineering, cheating, or reselling access is prohibited."),
+                LegalSection(title: "3. Virtual Goods & Purchases", body: "Gem packs and cosmetic items are virtual goods with no cash value and are non-refundable except where required by law. Keep your purchase receipts to restore entitlements across devices."),
+                LegalSection(title: "4. Fair Play", body: "You agree not to exploit bugs, automate gameplay, or harass other community members. We may suspend access for misconduct."),
+                LegalSection(title: "5. User Content", body: "Replay GIFs and share messages you generate remain yours, but by sharing them you grant us a worldwide license to display and promote them within the game and on social channels."),
+                LegalSection(title: "6. Updates & Availability", body: "Features may change as we balance difficulty, add content, or address bugs. We are not liable for service outages or data loss beyond our reasonable control."),
+                LegalSection(title: "7. Disclaimer & Liability", body: "The game is provided \"as is\" without warranties. Our liability is limited to the maximum extent permitted by law and never exceeds the amount you paid in the preceding six months."),
+                LegalSection(title: "8. Governing Law", body: "These terms are governed by the laws of California, USA, excluding conflict of law rules. Disputes will be handled in San Francisco County courts."),
+                LegalSection(title: "9. Support", body: "Contact support@orbitflipfrenzy.com for help with purchases, bug reports, or accessibility requests."),
+                LegalSection(title: "10. Changes", body: "We may update these terms. Continued play after changes means you accept the new terms. We will post updates in the app and revise the date above.")
+            ]
+        }
+    }
+}

--- a/OrbitFlipFrenzy/LegalViewController.swift
+++ b/OrbitFlipFrenzy/LegalViewController.swift
@@ -1,0 +1,101 @@
+import UIKit
+
+final class LegalViewController: UIViewController {
+    private let document: LegalDocument
+
+    private lazy var subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = UIColor.white.withAlphaComponent(0.75)
+        label.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.text = document.subtitle
+        return label
+    }()
+
+    private lazy var textView: UITextView = {
+        let view = UITextView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = GamePalette.deepNavy.withAlphaComponent(0.4)
+        view.layer.cornerRadius = 16
+        view.textContainerInset = UIEdgeInsets(top: 18, left: 16, bottom: 18, right: 16)
+        view.textColor = .white
+        view.tintColor = GamePalette.cyan
+        view.isEditable = false
+        view.alwaysBounceVertical = true
+        view.adjustsFontForContentSizeCategory = true
+        view.attributedText = makeAttributedText()
+        view.accessibilityLabel = document.title
+        return view
+    }()
+
+    init(document: LegalDocument) {
+        self.document = document
+        super.init(nibName: nil, bundle: nil)
+        title = document.title
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
+                                                            target: self,
+                                                            action: #selector(dismissSelf))
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = GamePalette.deepNavy
+        view.addSubview(subtitleLabel)
+        view.addSubview(textView)
+
+        NSLayoutConstraint.activate([
+            subtitleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            subtitleLabel.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+            subtitleLabel.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+
+            textView.topAnchor.constraint(equalTo: subtitleLabel.bottomAnchor, constant: 16),
+            textView.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+            textView.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+            textView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16)
+        ])
+    }
+
+    private func makeAttributedText() -> NSAttributedString {
+        let attributed = NSMutableAttributedString()
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineSpacing = 4
+        paragraph.paragraphSpacing = 12
+
+        let introAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.preferredFont(forTextStyle: .body),
+            .foregroundColor: UIColor.white,
+            .paragraphStyle: paragraph
+        ]
+
+        attributed.append(NSAttributedString(string: document.introduction + "\n\n", attributes: introAttributes))
+
+        let headingParagraph = NSMutableParagraphStyle()
+        headingParagraph.lineSpacing = 2
+        headingParagraph.paragraphSpacing = 6
+
+        for section in document.sections {
+            let headingAttributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.preferredFont(forTextStyle: .headline),
+                .foregroundColor: GamePalette.solarGold,
+                .paragraphStyle: headingParagraph
+            ]
+            attributed.append(NSAttributedString(string: section.title + "\n", attributes: headingAttributes))
+
+            attributed.append(NSAttributedString(string: section.body + "\n\n", attributes: introAttributes))
+        }
+
+        return attributed
+    }
+
+    @objc
+    private func dismissSelf() {
+        dismiss(animated: true)
+    }
+}


### PR DESCRIPTION
## Summary
- add structured privacy policy and terms of use content for in-app display
- present legal documents with a reusable UIKit controller and neon-themed styling
- expose privacy and terms buttons on the menu and wire them through the delegate stack

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5503b80888328bc5c03719e9c1c94